### PR TITLE
Fix convert-to-sketchpad text loss, improve dialog defaults and resiz…

### DIFF
--- a/protovibe-project-template/plugins/protovibe/src/backend/convert-to-sketchpad.ts
+++ b/protovibe-project-template/plugins/protovibe/src/backend/convert-to-sketchpad.ts
@@ -317,7 +317,15 @@ function flattenForUngrouped(root: SnapshotNode, keep: Set<string>): SnapshotNod
         : node.hasChildrenProp
           ? (node.children || []).filter(c => c.kind === 'element')
           : [];
-      items.push({ ...node, children: [], hasChildrenProp: false, flatShell: content.length > 0 });
+      // When nothing is lifted out, keep the rendered subtree on the shell so
+      // text-bearing components (allowTextInChildren) still recover their text
+      // via subtreeText at emit time.
+      items.push({
+        ...node,
+        children: content.length > 0 ? [] : node.children,
+        hasChildrenProp: false,
+        flatShell: content.length > 0,
+      });
       content.forEach(handle);
       return;
     }

--- a/protovibe-project-template/plugins/protovibe/src/ui/components/ConvertToSketchpadDialog.tsx
+++ b/protovibe-project-template/plugins/protovibe/src/ui/components/ConvertToSketchpadDialog.tsx
@@ -13,8 +13,12 @@ interface ConvertToSketchpadDialogProps {
 }
 
 export function ConvertToSketchpadDialog({ file, snapshot, onClose }: ConvertToSketchpadDialogProps) {
-  const [layoutMode, setLayoutMode] = useState<'flex' | 'absolute' | 'flat'>('flex');
-  const [flattened, setFlattened] = useState<Set<string>>(new Set());
+  // Defaults: absolute (non-flat) with every component flattened to HTML —
+  // the most reliable conversion.
+  const [layoutMode, setLayoutMode] = useState<'flex' | 'absolute' | 'flat'>('absolute');
+  const [flattened, setFlattened] = useState<Set<string>>(
+    () => new Set(snapshot.foundComponents.map(c => c.componentId)),
+  );
   const [busy, setBusy] = useState(false);
 
   useEffect(() => {
@@ -159,15 +163,15 @@ export function ConvertToSketchpadDialog({ file, snapshot, onClose }: ConvertToS
         )}
 
         <div style={sectionTitleStyle}>Layout</div>
-        <label style={labelStyle}>
-          <input type="radio" name="pv-convert-layout" checked={layoutMode === 'flex'} onChange={() => setLayoutMode('flex')} />
-          <span style={{ color: theme.text_default }}>Keep flex layout</span>
-          <span style={{ marginLeft: 'auto', fontSize: 10, color: theme.text_tertiary }}>structure stays fluid</span>
-        </label>
         <label style={labelStyle} data-testid="convert-layout-absolute">
           <input type="radio" name="pv-convert-layout" checked={layoutMode === 'absolute'} onChange={() => setLayoutMode('absolute')} />
           <span style={{ color: theme.text_default }}>Convert to absolute positions</span>
           <span style={{ marginLeft: 'auto', fontSize: 10, color: theme.text_tertiary }}>freeze measured layout</span>
+        </label>
+        <label style={labelStyle}>
+          <input type="radio" name="pv-convert-layout" checked={layoutMode === 'flex'} onChange={() => setLayoutMode('flex')} />
+          <span style={{ color: theme.text_default }}>Keep flex layout</span>
+          <span style={{ marginLeft: 'auto', fontSize: 10, color: theme.text_tertiary }}>structure stays fluid</span>
         </label>
         <label style={labelStyle} data-testid="convert-layout-flat">
           <input type="radio" name="pv-convert-layout" checked={layoutMode === 'flat'} onChange={() => setLayoutMode('flat')} />

--- a/protovibe-project-template/plugins/protovibe/src/ui/sketchpad-bridge.ts
+++ b/protovibe-project-template/plugins/protovibe/src/ui/sketchpad-bridge.ts
@@ -335,14 +335,27 @@ function collectPvLocs(el: HTMLElement): { name: string; value: string }[] {
   return locs;
 }
 
+/**
+ * Effective resize mode for a sketchpad element. An explicit data-pv-resizable
+ * attribute always wins. Without one, components (data-pv-component-id) resize
+ * width-only — their inner flex layout derives its own height — while plain
+ * HTML elements (divs/spans/svgs produced by Convert to Sketchpad) are
+ * absolutely positioned boxes and resize on both axes.
+ */
+function getResizeMode(el: HTMLElement): 'both' | 'horizontal' | 'vertical' {
+  const explicit = el.getAttribute('data-pv-resizable');
+  if (explicit === 'both' || explicit === 'horizontal' || explicit === 'vertical') return explicit;
+  return el.hasAttribute('data-pv-component-id') ? 'horizontal' : 'both';
+}
+
 /** Check if pointer is near any resizable edge/corner and return which one. */
 function getResizeEdge(el: HTMLElement, clientX: number, clientY: number): ResizeEdge | null {
   const rect = el.getBoundingClientRect();
-  const resizeMode = el.getAttribute('data-pv-resizable');
+  const resizeMode = getResizeMode(el);
   const resizeBoth = resizeMode === 'both';
-  const allowH = resizeBoth || resizeMode === 'horizontal' || resizeMode === null;
+  const allowH = resizeBoth || resizeMode === 'horizontal';
   const allowV = resizeBoth || resizeMode === 'vertical';
-  const allowLeft = resizeBoth || resizeMode === 'horizontal' || resizeMode === null;
+  const allowLeft = allowH;
 
   const nearRight = allowH && clientX >= rect.right - RESIZE_EDGE_PX && clientX <= rect.right + RESIZE_EDGE_PX;
   const nearLeft = allowLeft && clientX >= rect.left - RESIZE_EDGE_PX && clientX <= rect.left + RESIZE_EDGE_PX;
@@ -635,17 +648,16 @@ function syncOverlays() {
   }
 
   // Resize affordances: only when exactly one sketchpad-el is selected.
-  //   - SE 8x8 square for data-pv-resizable="both" (the only mode where getResizeEdge returns 'se').
-  //   - E thin vertical pill for the width-only modes (data-pv-resizable="horizontal" or
-  //     missing), where right-edge horizontal resize is allowed but the SE corner is not.
+  //   - SE 8x8 square for the 'both' mode (the only mode where getResizeEdge returns 'se').
+  //   - E thin vertical pill for the width-only 'horizontal' mode, where right-edge
+  //     horizontal resize is allowed but the SE corner is not.
   const single = selectedEls.length === 1 ? selectedEls[0] : null;
   const isSingleSketchpadEl = !!single && single.isConnected && single.hasAttribute('data-pv-sketchpad-el');
-  const resizeMode = isSingleSketchpadEl ? single!.getAttribute('data-pv-resizable') : null;
+  const resizeMode = isSingleSketchpadEl ? getResizeMode(single!) : null;
   const showSeAffordance = isSingleSketchpadEl && resizeMode === 'both';
-  // East handle covers the "width only" cases. Excludes 'both' (SE handle conveys it)
+  // East handle covers the width-only case. Excludes 'both' (SE handle conveys it)
   // and 'vertical' (no horizontal resize allowed).
-  const showEastAffordance = isSingleSketchpadEl
-    && (resizeMode === 'horizontal' || resizeMode === null);
+  const showEastAffordance = isSingleSketchpadEl && resizeMode === 'horizontal';
 
   if (showSeAffordance) {
     if (!resizeAffordance) {


### PR DESCRIPTION
…e modes

- Flat (ungrouped) conversion: kept components whose content is not lifted out now retain their rendered subtree, so allowTextInChildren components (TextHeading, TextParagraph, ...) keep their text instead of pasting empty.
- Convert to Sketchpad dialog: default to absolute (non-flat) layout with all components flattened, and list the absolute option first — it is the most reliable conversion.
- Sketchpad resize: elements without an explicit data-pv-resizable attribute now resize on both axes when they are plain HTML elements (converted divs, spans, svgs); components stay width-only since their inner flex layout derives its own height.


Claude-Session: https://claude.ai/code/session_016wJbruLuwkMThLA5MXGSTN