### PR TITLE
Sketchpad marquee: select nested blocks and allow Cmd-drag from any p…

### DIFF
--- a/protovibe-project-template/plugins/protovibe/src/sketchpads/components/SketchpadApp.tsx
+++ b/protovibe-project-template/plugins/protovibe/src/sketchpads/components/SketchpadApp.tsx
@@ -1207,10 +1207,14 @@ export function SketchpadApp() {
     return () => window.removeEventListener('keydown', handler);
   }, [selectedFrameIds, handleDeleteFramesMulti, pendingAction, zoomToCenter, zoomByFactor, handleCopyFrames, handleCutFrames, handlePasteFrames]);
 
-  // Marquee selection: starts on canvas background or empty area inside a frame.
+  // Marquee selection: starts on canvas background or empty area inside a frame,
+  // or from any point when Cmd/Ctrl is held (the bridge defers its deep-click so
+  // we can take over once the drag threshold is passed).
   // Containment-only: an element/frame must be fully enclosed.
   // If any frame is fully contained, only frames are selected (no mixed selection).
-  // Otherwise, selects top-level pv-blocks within the frame the marquee started in.
+  // Otherwise, selects the top-most fully-contained pv-blocks within the frame the
+  // marquee started in — nested blocks count individually, but collapse into an
+  // ancestor block when that ancestor is itself fully contained.
   useEffect(() => {
     const MOVE_THRESHOLD = 3;
     let dragging = false;
@@ -1238,13 +1242,23 @@ export function SketchpadApp() {
         };
       }
       if (!startFrame) return { mode: 'none', els: [] };
-      const allBlocks = Array.from(startFrame.querySelectorAll('[data-pv-block]')) as HTMLElement[];
-      const topLevel = allBlocks.filter((el) => !el.parentElement?.closest('[data-pv-block]'));
-      const contained = topLevel.filter((el) => isInside(rect, el.getBoundingClientRect()));
+      const allBlocks = (Array.from(startFrame.querySelectorAll('[data-pv-block]')) as HTMLElement[])
+        .filter((el) => el.getAttribute('data-pv-block'));
+      const containedSet = new Set(allBlocks.filter((el) => isInside(rect, el.getBoundingClientRect())));
+      // Top-most contained blocks win: a nested block is selectable on its own,
+      // but collapses into an ancestor block that is itself fully contained.
+      const topmost = Array.from(containedSet).filter((el) => {
+        let ancestor = el.parentElement?.closest('[data-pv-block]') as HTMLElement | null;
+        while (ancestor) {
+          if (containedSet.has(ancestor)) return false;
+          ancestor = ancestor.parentElement?.closest('[data-pv-block]') as HTMLElement | null;
+        }
+        return true;
+      });
       return {
         mode: 'blocks',
-        blockIds: contained.map((el) => el.getAttribute('data-pv-block')!).filter(Boolean),
-        els: contained,
+        blockIds: topmost.map((el) => el.getAttribute('data-pv-block')!),
+        els: topmost,
       };
     };
 
@@ -1253,13 +1267,20 @@ export function SketchpadApp() {
       if (spaceHeldRef.current) return;
       const t = e.target as HTMLElement | null;
       if (!t) return;
-      if (t.closest('[data-pv-block], [data-pv-sketchpad-el]')) return;
+      // Cmd/Ctrl held: a marquee may start from any point, including on top of
+      // elements and the focused-frame drag overlay — both yield when the
+      // modifier is down (the overlay bails out of its own drag and the bridge
+      // defers its deep-click to pointerup).
+      const forceMarquee = e.metaKey || e.ctrlKey;
+      if (!forceMarquee) {
+        if (t.closest('[data-pv-block], [data-pv-sketchpad-el]')) return;
+        // The focused-frame drag overlay handles its own pointer flow. Without
+        // this guard the window-level marquee handler also engages on the same
+        // pointerdown and runs querySelectorAll + setMarqueePreview on every
+        // move, which manifests as severe lag while dragging the frame.
+        if (t.closest('[data-sketchpad-frame-overlay]')) return;
+      }
       if (t.closest('[data-sketchpad-resize-handle]')) return;
-      // The focused-frame drag overlay handles its own pointer flow. Without
-      // this guard the window-level marquee handler also engages on the same
-      // pointerdown and runs querySelectorAll + setMarqueePreview on every
-      // move, which manifests as severe lag while dragging the frame.
-      if (t.closest('[data-sketchpad-frame-overlay]')) return;
       const frameRoot = t.closest('[data-sketchpad-frame-root]');
       const frameContent = t.closest('[data-sketchpad-frame]') as HTMLElement | null;
       if (frameRoot && !frameContent) return;

--- a/protovibe-project-template/plugins/protovibe/src/ui/sketchpad-bridge.ts
+++ b/protovibe-project-template/plugins/protovibe/src/ui/sketchpad-bridge.ts
@@ -109,6 +109,17 @@ let ghostEls: HTMLElement[] = [];
 let currentActiveSourceId: string | null = null;
 let spaceHeld = false;
 
+// Cmd/Ctrl+pointerdown on an element defers the deep-click selection to
+// pointerup, so a Cmd-drag can become a marquee (owned by SketchpadApp's
+// window-level handler) instead of a click-select or element drag.
+let pendingMetaClick: {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  target: HTMLElement;
+  isMulti: boolean;
+} | null = null;
+
 window.addEventListener('blur', () => {
   spaceHeld = false;
 });
@@ -1027,7 +1038,7 @@ function handlePointerDown(e: PointerEvent) {
   const primarySel = selectedEls.length === 1 ? selectedEls[0] : null;
   const selEdge = primarySel?.hasAttribute('data-pv-sketchpad-el') ? getResizeEdge(primarySel, e.clientX, e.clientY) : null;
 
-  if (primarySel && selEdge && !isMulti) {
+  if (primarySel && selEdge && !isMulti && !(e.metaKey || e.ctrlKey)) {
     e.preventDefault();
     e.stopPropagation();
     const rect = primarySel.getBoundingClientRect();
@@ -1052,6 +1063,22 @@ function handlePointerDown(e: PointerEvent) {
   }
 
   const path = getInspectablePath(e.target);
+
+  // Cmd/Ctrl held over an element: the user may be starting a marquee from on
+  // top of it (SketchpadApp's window-level handler takes over past the drag
+  // threshold). Defer the deep-click selection to pointerup and let the event
+  // propagate — no stopPropagation, no drag/resize setup.
+  if ((e.metaKey || e.ctrlKey) && path.length > 0) {
+    pendingMetaClick = {
+      pointerId: e.pointerId,
+      startX: e.clientX,
+      startY: e.clientY,
+      target: path[path.length - 1],
+      isMulti,
+    };
+    e.preventDefault();
+    return;
+  }
 
   // Custom double-click drill-down interception
   if (isDoubleClick && selectedEls.length === 1 && path.includes(selectedEls[0]) && !isMulti) {
@@ -1079,10 +1106,8 @@ function handlePointerDown(e: PointerEvent) {
   let isClickingSelected = false;
 
   if (path.length > 0) {
-    if (e.metaKey || e.ctrlKey) {
-      // Cmd/Ctrl + Click -> Direct deep selection
-      nextTarget = path[path.length - 1];
-    } else if (!isMulti && selectedEls.some(sel => path.includes(sel))) {
+    // (Cmd/Ctrl deep selection already returned above as a deferred click.)
+    if (!isMulti && selectedEls.some(sel => path.includes(sel))) {
       // Clicked down on an already selected element in a group -> keep group selection to drag it
       nextTarget = selectedEls.find(sel => path.includes(sel))!;
       isClickingSelected = true;
@@ -1177,6 +1202,14 @@ function handlePointerMove(e: PointerEvent) {
     return;
   }
 
+  // A Cmd/Ctrl-drag past the threshold means the marquee took over — drop the
+  // deferred deep-click so pointerup doesn't select underneath the marquee.
+  if (pendingMetaClick && e.pointerId === pendingMetaClick.pointerId) {
+    const dx = Math.abs(e.clientX - pendingMetaClick.startX);
+    const dy = Math.abs(e.clientY - pendingMetaClick.startY);
+    if (dx >= DRAG_THRESHOLD || dy >= DRAG_THRESHOLD) pendingMetaClick = null;
+  }
+
   if ((resizeState && e.pointerId === resizeState.pointerId) ||
       (dragState && e.pointerId === dragState.pointerId)) {
     e.preventDefault();
@@ -1246,6 +1279,20 @@ function handlePointerUp(e: PointerEvent) {
     latestClientX = e.clientX;
     latestClientY = e.clientY;
     applyPointerMoveUpdate();
+  }
+
+  // Deferred Cmd/Ctrl deep-click: no marquee drag happened, apply the deep
+  // selection now. Don't stop propagation — SketchpadApp's pointerup still
+  // clears frame multi-selection on a plain click.
+  if (pendingMetaClick && e.pointerId === pendingMetaClick.pointerId) {
+    const pending = pendingMetaClick;
+    pendingMetaClick = null;
+    if (pending.target.isConnected) {
+      clearHover();
+      setSelection(pending.target, pending.isMulti);
+      notifyInspector(pending.target);
+    }
+    return;
   }
 
   // Handle resize end


### PR DESCRIPTION
…oint

Marquee selection previously only considered top-level pv-blocks, so children of a container could never be marquee-selected. Candidates are now all fully-contained blocks, collapsed to the top-most: a nested block is selected individually unless an ancestor block is itself fully enclosed, in which case the ancestor wins.

Holding Cmd/Ctrl now starts a marquee from any point, including on top of elements and the focused-frame drag overlay. The bridge defers its Cmd+click deep-selection to pointerup (cancelled once the drag passes the threshold) and lets the pointerdown propagate instead of claiming it, so the window-level marquee handler can take over on drag while a plain Cmd+click still deep-selects.


Claude-Session: https://claude.ai/code/session_01H2boJu83YBdNenPknu8yHd