### PR TITLE
Debounce Vite crash state behind a 10s loading cover

### DIFF
--- a/protovibe-project-template/.claude/skills/verify/SKILL.md
+++ b/protovibe-project-template/.claude/skills/verify/SKILL.md
@@ -18,6 +18,10 @@ pnpm dev              # vite on http://localhost:3000
   `plugins/protovibe/dist/ui/{inspector,bridge,sketchpad-bridge}.js` at
   page-serve time, so a rebuild takes effect on the next page load without
   restarting vite.
+- BUT server-side plugin code (`dist/index.js` — middleware, endpoints) is NOT
+  reloaded by the plugin's automatic `server.restart()`: node's ESM cache keeps
+  the old module. Kill the `pnpm dev` process and start it again to load new
+  server-side plugin code.
 - The Protovibe shell (editor UI) is at `http://localhost:3000/protovibe.html`
   (`?tab=app|components|sketchpad`). The bare app is at `/`.
 - Use `--noproxy localhost` with curl; outbound proxy breaks localhost otherwise.

--- a/protovibe-project-template/.claude/skills/verify/SKILL.md
+++ b/protovibe-project-template/.claude/skills/verify/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: verify
+description: Build, launch, and drive the Protovibe shell (template + vite-plugin-protovibe) to verify UI/plugin changes at runtime.
+---
+
+# Verifying protovibe-project-template / plugins/protovibe changes
+
+## Build & launch
+
+```bash
+cd protovibe-project-template
+pnpm install          # postinstall also builds plugins/protovibe into dist/
+pnpm dev              # vite on http://localhost:3000
+```
+
+- After editing plugin source (`plugins/protovibe/src/**`), rebuild with
+  `pnpm --dir plugins/protovibe build` — the dev server injects
+  `plugins/protovibe/dist/ui/{inspector,bridge,sketchpad-bridge}.js` at
+  page-serve time, so a rebuild takes effect on the next page load without
+  restarting vite.
+- The Protovibe shell (editor UI) is at `http://localhost:3000/protovibe.html`
+  (`?tab=app|components|sketchpad`). The bare app is at `/`.
+- Use `--noproxy localhost` with curl; outbound proxy breaks localhost otherwise.
+
+## Drive it
+
+- Playwright lives in the monorepo **root** `node_modules` (`@playwright/test`);
+  run driver scripts from the repo root so module resolution works.
+  Pre-installed Chromium: launch with
+  `executablePath: '/opt/pw-browsers/chromium-1194/chrome-linux/chrome'`
+  (check the versioned dir name under `/opt/pw-browsers/`).
+- The shell renders the user app in an iframe; shell UI (banners, overlays,
+  nav) is in the top document, Vite's `vite-error-overlay` is inside the
+  iframe.
+- Shell overlays may be rendered once per iframe tab wrapper (app, sketchpad,
+  components) — `getByText` can hit strict-mode violations; iterate `.all()`
+  and check `isVisible()` per element.
+
+## Useful flows
+
+- Simulate an app crash: append `\nconst broken = {;\n` to `src/App.tsx`
+  (HMR pushes the compile error within ~1–2s); restore the file to recover.
+- Fresh page load while broken shows NO `vite-error-overlay` — the entry
+  module request just 500s and the canvas stays blank (bridge.ts detects this
+  via failing same-origin script loads).

--- a/protovibe-project-template/.claude/skills/verify/SKILL.md
+++ b/protovibe-project-template/.claude/skills/verify/SKILL.md
@@ -40,6 +40,10 @@ pnpm dev              # vite on http://localhost:3000
 
 - Simulate an app crash: append `\nconst broken = {;\n` to `src/App.tsx`
   (HMR pushes the compile error within ~1–2s); restore the file to recover.
+  Rarely — especially right after a plugin-rebuild-triggered server restart —
+  the client receives the `hmr update` but never re-fetches the module, so the
+  app silently keeps running the last good code and no overlay appears; retry
+  the break rather than chasing it.
 - Fresh page load while broken shows NO `vite-error-overlay` — the entry
   module request just 500s and the canvas stays blank (bridge.ts detects this
   via failing same-origin script loads).

--- a/protovibe-project-template/plugins/protovibe/src/protovibe-source.ts
+++ b/protovibe-project-template/plugins/protovibe/src/protovibe-source.ts
@@ -117,6 +117,25 @@ export function protovibeSourcePlugin(): Plugin {
         }
       });
 
+      // Timestamp of the last watched-source change. The shell polls this
+      // during a crash episode to keep the loading cover up while an agent is
+      // still editing (see ProtovibeApp's crash-episode machine).
+      let lastSourceChangeAt = 0;
+      server.watcher.on('change', (changedFile) => {
+        if (changedFile === inspectorPath || changedFile === bridgePath || changedFile === pluginIndexPath) return;
+        // The sketchpad registry is rewritten by the plugin itself on ordinary
+        // requests — it is not a code edit and must not prolong a crash episode.
+        if (changedFile.endsWith(path.join('sketchpads', '_registry.json'))) return;
+        lastSourceChangeAt = Date.now();
+      });
+      server.middlewares.use('/__hmr-activity', (req, res) => {
+        res.setHeader('Content-Type', 'application/json');
+        res.setHeader('Cache-Control', 'no-store');
+        res.end(JSON.stringify({
+          msSinceLastChange: lastSourceChangeAt ? Date.now() - lastSourceChangeAt : null,
+        }));
+      });
+
       const srcPath = path.resolve(process.cwd(), 'src');
 
       // When a new component file is added, invalidate its SSR cache entry so

--- a/protovibe-project-template/plugins/protovibe/src/ui/ProtovibeApp.tsx
+++ b/protovibe-project-template/plugins/protovibe/src/ui/ProtovibeApp.tsx
@@ -13,6 +13,7 @@ import { NotEditableDialog } from './components/NotEditableDialog';
 import { ToastViewport } from './components/ToastViewport';
 import { GitMenu } from './components/GitMenu';
 import { GitSyncBanner } from './components/GitSyncBanner';
+import { CrashLoadingOverlay } from './components/CrashLoadingOverlay';
 import { useGitSync } from './hooks/useGitSync';
 import { useIframeBridge } from './hooks/useIframeBridge';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
@@ -25,6 +26,16 @@ import { openInBrowser, handleExternalLinkClick } from './utils/openExternal';
 import { commentIdSelector } from '../shared/comments';
 import type { CommentContext } from '../shared/comments';
 import { consumePersistedAppPath, persistAppPath, setCurrentAppPath, getCurrentAppPath } from './utils/appPath';
+
+// How long a Vite crash may sit behind the loading cover before the full
+// error state is shown. AI agents editing code routinely leave the app broken
+// for a few seconds between writes; the next HMR update clears the overlay
+// and the user never needs to see a crash.
+const VITE_ERROR_GRACE_MS = 10_000;
+
+// none: healthy · pending: crash inside the grace period (canvas covered by a
+// loading state) · error: crash outlived the grace period (full error shown).
+type ViteErrorPhase = 'none' | 'pending' | 'error';
 
 function parseTabParam(search: string): IframeTab {
   const tab = new URLSearchParams(search).get('tab');
@@ -42,7 +53,23 @@ export const ProtovibeApp: React.FC = () => {
     () => parseTabParam(window.location.search)
   );
   const [activeSidebarTab, setActiveSidebarTab] = useState<SidebarTab>('design');
-  const [showErrorBanner, setShowErrorBanner] = useState(false);
+  const [viteErrorPhase, setViteErrorPhase] = useState<ViteErrorPhase>('none');
+  // Ref mirror so the (once-registered) message handler and the grace timer
+  // can read the current phase without re-subscribing on every change.
+  const viteErrorPhaseRef = useRef<ViteErrorPhase>('none');
+  const viteErrorTimerRef = useRef<number | null>(null);
+
+  const clearViteErrorTimer = useCallback(() => {
+    if (viteErrorTimerRef.current !== null) {
+      window.clearTimeout(viteErrorTimerRef.current);
+      viteErrorTimerRef.current = null;
+    }
+  }, []);
+
+  const setViteError = useCallback((phase: ViteErrorPhase) => {
+    viteErrorPhaseRef.current = phase;
+    setViteErrorPhase(phase);
+  }, []);
   // Unread-thread count broadcast by the (always-mounted) CommentsTab, surfaced
   // as a dot on the Comments nav tab even while that panel is hidden.
   const [unreadComments, setUnreadComments] = useState(0);
@@ -270,15 +297,31 @@ export const ProtovibeApp: React.FC = () => {
     return () => window.removeEventListener('keydown', handler);
   }, [activeIframeTab]);
 
-  // Listen for Vite error overlay detection from iframe bridge
+  // Listen for Vite error overlay detection from the iframe bridge. A crash is
+  // often just a transient state while an AI agent edits code, so don't alarm
+  // the user right away: cover the canvas with a loading state first, and only
+  // surface the full error if no HMR update clears it within the grace period.
   useEffect(() => {
     const handler = (e: MessageEvent) => {
-      if (e.data?.type === 'PV_VITE_ERROR') setShowErrorBanner(true);
-      if (e.data?.type === 'PV_VITE_ERROR_CLEARED') setShowErrorBanner(false);
+      if (e.data?.type === 'PV_VITE_ERROR' && viteErrorPhaseRef.current === 'none') {
+        setViteError('pending');
+        clearViteErrorTimer();
+        viteErrorTimerRef.current = window.setTimeout(() => {
+          viteErrorTimerRef.current = null;
+          if (viteErrorPhaseRef.current === 'pending') setViteError('error');
+        }, VITE_ERROR_GRACE_MS);
+      }
+      if (e.data?.type === 'PV_VITE_ERROR_CLEARED') {
+        clearViteErrorTimer();
+        setViteError('none');
+      }
     };
     window.addEventListener('message', handler);
-    return () => window.removeEventListener('message', handler);
-  }, []);
+    return () => {
+      window.removeEventListener('message', handler);
+      clearViteErrorTimer();
+    };
+  }, [setViteError, clearViteErrorTimer]);
 
   // Re-send state whenever a specific iframe reloads (e.g. HMR full-reload)
   const handleIframeLoad = useCallback((ref: React.RefObject<HTMLIFrameElement | null>) => {
@@ -363,7 +406,8 @@ export const ProtovibeApp: React.FC = () => {
   const handleRestart = async () => {
     try {
       await restartServer();
-      setShowErrorBanner(false);
+      clearViteErrorTimer();
+      setViteError('none');
     } catch (e) {
       console.error('Restart failed', e);
     }
@@ -420,7 +464,7 @@ export const ProtovibeApp: React.FC = () => {
         inspectorOpen={inspectorOpen}
         onToggleInspector={() => toggleInspector()}
       />
-      {showErrorBanner && (
+      {viteErrorPhase === 'error' && (
         <div style={{
           display: 'flex', justifyContent: 'space-between', alignItems: 'center',
           padding: '16px 20px', background: theme.destructive_low,
@@ -448,7 +492,7 @@ export const ProtovibeApp: React.FC = () => {
               Restart
             </button>
           </div>
-          <button onClick={() => setShowErrorBanner(false)} style={{ background: 'transparent', color: theme.destructive_default, border: 'none', cursor: 'pointer', padding: '4px', display: 'flex', alignItems: 'center', flexShrink: 0 }}>
+          <button onClick={() => setViteError('none')} style={{ background: 'transparent', color: theme.destructive_default, border: 'none', cursor: 'pointer', padding: '4px', display: 'flex', alignItems: 'center', flexShrink: 0 }}>
             <X size={16} />
           </button>
         </div>
@@ -581,7 +625,7 @@ export const ProtovibeApp: React.FC = () => {
                 <Smartphone size={16} />
               </button>
             </div>
-            <div style={{ flex: 1, display: 'flex', justifyContent: 'center', minHeight: 0, background: mobileWidth ? theme.bg_strong : 'transparent' }}>
+            <div style={{ flex: 1, display: 'flex', justifyContent: 'center', minHeight: 0, position: 'relative', background: mobileWidth ? theme.bg_strong : 'transparent' }}>
               <iframe
                 ref={appIframeRef}
                 src={initialAppSrc}
@@ -593,23 +637,26 @@ export const ProtovibeApp: React.FC = () => {
                 }}
                 onLoad={() => handleIframeLoad(appIframeRef)}
               />
+              {viteErrorPhase === 'pending' && <CrashLoadingOverlay onUndo={handleUndo} />}
             </div>
           </div>
-          <div style={{ flex: 1, display: activeIframeTab === 'sketchpad' ? 'flex' : 'none', minHeight: 0 }}>
+          <div style={{ flex: 1, display: activeIframeTab === 'sketchpad' ? 'flex' : 'none', minHeight: 0, position: 'relative' }}>
             <iframe
               ref={sketchpadIframeRef}
               src="/sketchpad.html"
               style={{ flex: 1, border: 'none', minWidth: 0 }}
               onLoad={() => handleIframeLoad(sketchpadIframeRef)}
             />
+            {viteErrorPhase === 'pending' && <CrashLoadingOverlay onUndo={handleUndo} />}
           </div>
-          <div style={{ flex: 1, display: activeIframeTab === 'components' ? 'flex' : 'none', minHeight: 0 }}>
+          <div style={{ flex: 1, display: activeIframeTab === 'components' ? 'flex' : 'none', minHeight: 0, position: 'relative' }}>
             <iframe
               ref={componentsIframeRef}
               src="/components.html"
               style={{ flex: 1, border: 'none', minWidth: 0 }}
               onLoad={() => handleIframeLoad(componentsIframeRef)}
             />
+            {viteErrorPhase === 'pending' && <CrashLoadingOverlay onUndo={handleUndo} />}
           </div>
           <div
             style={{

--- a/protovibe-project-template/plugins/protovibe/src/ui/ProtovibeApp.tsx
+++ b/protovibe-project-template/plugins/protovibe/src/ui/ProtovibeApp.tsx
@@ -27,11 +27,25 @@ import { commentIdSelector } from '../shared/comments';
 import type { CommentContext } from '../shared/comments';
 import { consumePersistedAppPath, persistAppPath, setCurrentAppPath, getCurrentAppPath } from './utils/appPath';
 
-// How long a Vite crash may sit behind the loading cover before the full
-// error state is shown. AI agents editing code routinely leave the app broken
-// for a few seconds between writes; the next HMR update clears the overlay
-// and the user never needs to see a crash.
-const VITE_ERROR_GRACE_MS = 10_000;
+// A Vite crash is often a transient state while an AI agent edits code, so the
+// shell runs each crash as an "episode" behind a loading cover instead of
+// alarming the user immediately:
+//   t+5s / t+10s — auto-refresh the app iframe (Vite doesn't always manage to
+//                  auto-reload out of a broken state; a refresh sometimes does)
+//   t+15s        — show the full error state, but only once watched source
+//                  files have stopped changing — an agent mid-task keeps the
+//                  loading cover up for as long as it keeps writing.
+// The episode clock is retained across those refreshes: a reloading document
+// re-reports its error state (see bridge.ts), which must not reset the counter.
+const CRASH_AUTO_REFRESH_AT_MS = [5_000, 10_000];
+const CRASH_FINAL_ERROR_AT_MS = 15_000;
+// A source change within this window counts as "agent still working" and
+// postpones the final error until the writes stop.
+const CRASH_ACTIVITY_EXTEND_MS = 10_000;
+// How long after an ambiguous "no error yet" report (a freshly loaded document
+// that may still crash — see bridge.ts) before the episode counts as recovered.
+const CRASH_RECOVERY_CONFIRM_MS = 2_500;
+const CRASH_TICK_MS = 1_000;
 
 // none: healthy · pending: crash inside the grace period (canvas covered by a
 // loading state) · error: crash outlived the grace period (full error shown).
@@ -77,22 +91,47 @@ export const ProtovibeApp: React.FC = () => {
   // error itself, using whatever detail it can recover.
   const [moduleLoadError, setModuleLoadError] = useState(false);
   const [viteErrorDetail, setViteErrorDetail] = useState<string | null>(null);
-  // Ref mirror so the (once-registered) message handler and the grace timer
+  // Ref mirror so the (once-registered) message handler and the episode tick
   // can read the current phase without re-subscribing on every change.
   const viteErrorPhaseRef = useRef<ViteErrorPhase>('none');
-  const viteErrorTimerRef = useRef<number | null>(null);
-
-  const clearViteErrorTimer = useCallback(() => {
-    if (viteErrorTimerRef.current !== null) {
-      window.clearTimeout(viteErrorTimerRef.current);
-      viteErrorTimerRef.current = null;
-    }
-  }, []);
+  // The active crash episode. It survives auto/manual refreshes so the
+  // countdown to the final error isn't reset by a reloading document.
+  // canvasBlanked: the app iframe was reloaded into a failed module load at
+  // some point, so it may need one more reload to come back after recovery.
+  const crashEpisodeRef = useRef<{ start: number; refreshesDone: number; canvasBlanked: boolean } | null>(null);
+  const crashTickRef = useRef<number | null>(null);
+  const crashRecoveryTimerRef = useRef<number | null>(null);
+  // Freshness of the last watched-source change, polled from the dev server
+  // during an episode (Infinity until a poll lands or when polling fails).
+  const crashActivityMsAgoRef = useRef<number>(Infinity);
 
   const setViteError = useCallback((phase: ViteErrorPhase) => {
     viteErrorPhaseRef.current = phase;
     setViteErrorPhase(phase);
   }, []);
+
+  const clearCrashRecoveryTimer = useCallback(() => {
+    if (crashRecoveryTimerRef.current !== null) {
+      window.clearTimeout(crashRecoveryTimerRef.current);
+      crashRecoveryTimerRef.current = null;
+    }
+  }, []);
+
+  const clearCrashTick = useCallback(() => {
+    if (crashTickRef.current !== null) {
+      window.clearInterval(crashTickRef.current);
+      crashTickRef.current = null;
+    }
+  }, []);
+
+  const endCrashEpisode = useCallback(() => {
+    crashEpisodeRef.current = null;
+    clearCrashTick();
+    clearCrashRecoveryTimer();
+    setViteError('none');
+    setModuleLoadError(false);
+    setViteErrorDetail(null);
+  }, [clearCrashTick, clearCrashRecoveryTimer, setViteError]);
   // Unread-thread count broadcast by the (always-mounted) CommentsTab, surfaced
   // as a dot on the Comments nav tab even while that panel is hidden.
   const [unreadComments, setUnreadComments] = useState(0);
@@ -116,6 +155,50 @@ export const ProtovibeApp: React.FC = () => {
   const sketchpadIframeRef = useRef<HTMLIFrameElement>(null);
   const componentsIframeRef = useRef<HTMLIFrameElement>(null);
   const appScrollPositionsRef = useRef<Array<{ el: Element; top: number; left: number }>>([]);
+
+  // Reload one canvas iframe (used by the crash covers, the crash banner, and
+  // the episode's auto-refresh schedule).
+  const reloadIframe = useCallback((ref: React.RefObject<HTMLIFrameElement | null>) => {
+    try {
+      ref.current?.contentWindow?.location.reload();
+    } catch {
+      if (ref.current) ref.current.src = ref.current.src; // eslint-disable-line no-self-assign
+    }
+  }, []);
+
+  // Begin a crash episode: cover the canvas and drive the auto-refresh /
+  // final-error schedule off one retained clock.
+  const startCrashEpisode = useCallback(() => {
+    crashEpisodeRef.current = { start: Date.now(), refreshesDone: 0, canvasBlanked: false };
+    crashActivityMsAgoRef.current = Infinity;
+    setViteError('pending');
+    clearCrashTick();
+    crashTickRef.current = window.setInterval(() => {
+      const ep = crashEpisodeRef.current;
+      if (!ep || viteErrorPhaseRef.current !== 'pending') return;
+
+      // Refresh the dev server's view of agent activity. A stale result is
+      // fine — the deadline check just uses the latest poll that has landed.
+      fetch('/__hmr-activity')
+        .then(r => r.json())
+        .then(d => {
+          crashActivityMsAgoRef.current = typeof d?.msSinceLastChange === 'number' ? d.msSinceLastChange : Infinity;
+        })
+        .catch(() => { crashActivityMsAgoRef.current = Infinity; });
+
+      const elapsed = Date.now() - ep.start;
+      if (ep.refreshesDone < CRASH_AUTO_REFRESH_AT_MS.length && elapsed >= CRASH_AUTO_REFRESH_AT_MS[ep.refreshesDone]) {
+        ep.refreshesDone += 1;
+        reloadIframe(appIframeRef);
+        return;
+      }
+      if (elapsed >= CRASH_FINAL_ERROR_AT_MS && crashActivityMsAgoRef.current >= CRASH_ACTIVITY_EXTEND_MS) {
+        clearCrashTick();
+        setViteErrorDetail(readOwnViteOverlayError());
+        setViteError('error');
+      }
+    }, CRASH_TICK_MS);
+  }, [setViteError, clearCrashTick, reloadIframe]);
 
   const captureAppScrollPositions = useCallback(() => {
     const doc = appIframeRef.current?.contentDocument;
@@ -320,41 +403,49 @@ export const ProtovibeApp: React.FC = () => {
     return () => window.removeEventListener('keydown', handler);
   }, [activeIframeTab]);
 
-  // Listen for Vite error overlay detection from the iframe bridge. A crash is
-  // often just a transient state while an AI agent edits code, so don't alarm
-  // the user right away: cover the canvas with a loading state first, and only
-  // surface the full error if no HMR update clears it within the grace period.
+  // Listen for Vite error reports from the iframe bridges. A crash is often
+  // just a transient state while an AI agent edits code, so it runs as an
+  // episode (see the CRASH_* constants) instead of alarming the user right away.
   useEffect(() => {
     const handler = (e: MessageEvent) => {
       if (e.data?.type === 'PV_VITE_ERROR') {
         // Last write wins: an overlay appearing in the iframe means the canvas
         // is no longer blank, a failed module load means it is.
         if (typeof e.data.moduleLoadError === 'boolean') setModuleLoadError(e.data.moduleLoadError);
-        if (viteErrorPhaseRef.current === 'none') {
-          setViteError('pending');
-          clearViteErrorTimer();
-          viteErrorTimerRef.current = window.setTimeout(() => {
-            viteErrorTimerRef.current = null;
-            if (viteErrorPhaseRef.current === 'pending') {
-              setViteErrorDetail(readOwnViteOverlayError());
-              setViteError('error');
-            }
-          }, VITE_ERROR_GRACE_MS);
-        }
+        if (e.data.moduleLoadError && crashEpisodeRef.current) crashEpisodeRef.current.canvasBlanked = true;
+        // An error during recovery confirmation means the app is still broken
+        // — keep the episode (and its clock).
+        clearCrashRecoveryTimer();
+        if (!crashEpisodeRef.current) startCrashEpisode();
       }
       if (e.data?.type === 'PV_VITE_ERROR_CLEARED') {
-        clearViteErrorTimer();
-        setViteError('none');
-        setModuleLoadError(false);
-        setViteErrorDetail(null);
+        if (!crashEpisodeRef.current) return;
+        // No CLEARED is definitive: vite removes and re-adds the overlay on
+        // every update cycle when a broken JS update rides along with a
+        // successful CSS one, and a freshly loaded document merely hasn't
+        // errored *yet*. Confirm recovery with a delay — a quick re-error
+        // cancels it, retaining the episode clock.
+        const fromAppIframe = e.source === appIframeRef.current?.contentWindow;
+        if (crashRecoveryTimerRef.current === null) {
+          crashRecoveryTimerRef.current = window.setTimeout(() => {
+            crashRecoveryTimerRef.current = null;
+            // A canvas left blank by a mid-crash reload can't apply HMR
+            // updates, so the fix that other iframes just confirmed never
+            // reaches it — revive it with one more reload.
+            const revive = !!crashEpisodeRef.current?.canvasBlanked && !fromAppIframe;
+            endCrashEpisode();
+            if (revive) reloadIframe(appIframeRef);
+          }, CRASH_RECOVERY_CONFIRM_MS);
+        }
       }
     };
     window.addEventListener('message', handler);
     return () => {
       window.removeEventListener('message', handler);
-      clearViteErrorTimer();
+      clearCrashTick();
+      clearCrashRecoveryTimer();
     };
-  }, [setViteError, clearViteErrorTimer]);
+  }, [startCrashEpisode, endCrashEpisode, clearCrashRecoveryTimer, clearCrashTick, reloadIframe]);
 
   // Re-send state whenever a specific iframe reloads (e.g. HMR full-reload)
   const handleIframeLoad = useCallback((ref: React.RefObject<HTMLIFrameElement | null>) => {
@@ -428,15 +519,6 @@ export const ProtovibeApp: React.FC = () => {
     });
   }, [runLockedMutation]);
 
-  // Reload one canvas iframe (used by the crash covers and the error banner).
-  const reloadIframe = useCallback((ref: React.RefObject<HTMLIFrameElement | null>) => {
-    try {
-      ref.current?.contentWindow?.location.reload();
-    } catch {
-      if (ref.current) ref.current.src = ref.current.src; // eslint-disable-line no-self-assign
-    }
-  }, []);
-
   const activeIframeRef =
     activeIframeTab === 'sketchpad' ? sketchpadIframeRef :
     activeIframeTab === 'components' ? componentsIframeRef :
@@ -453,8 +535,7 @@ export const ProtovibeApp: React.FC = () => {
   const handleRestart = async () => {
     try {
       await restartServer();
-      clearViteErrorTimer();
-      setViteError('none');
+      endCrashEpisode();
     } catch (e) {
       console.error('Restart failed', e);
     }
@@ -557,7 +638,7 @@ export const ProtovibeApp: React.FC = () => {
               Restart
             </button>
           </div>
-          <button onClick={() => setViteError('none')} style={{ background: 'transparent', color: theme.destructive_default, border: 'none', cursor: 'pointer', padding: '4px', display: 'flex', alignItems: 'center', flexShrink: 0 }}>
+          <button onClick={endCrashEpisode} style={{ background: 'transparent', color: theme.destructive_default, border: 'none', cursor: 'pointer', padding: '4px', display: 'flex', alignItems: 'center', flexShrink: 0 }}>
             <X size={16} />
           </button>
         </div>

--- a/protovibe-project-template/plugins/protovibe/src/ui/ProtovibeApp.tsx
+++ b/protovibe-project-template/plugins/protovibe/src/ui/ProtovibeApp.tsx
@@ -1,7 +1,7 @@
 // plugins/protovibe/src/ui/ProtovibeApp.tsx
 import React, { useRef, useState, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
-import { ArrowLeft, ArrowRight, RotateCw, Home, ExternalLink, Smartphone, X, Undo2, HelpCircle, BookOpen, Keyboard, Bug, Eraser } from 'lucide-react';
+import { ArrowLeft, ArrowRight, RotateCw, RefreshCw, Home, ExternalLink, Smartphone, X, Undo2, HelpCircle, BookOpen, Keyboard, Bug, Eraser } from 'lucide-react';
 import { useFloatingDropdownPosition } from './hooks/useFloatingDropdownPosition';
 import { ShellNavBar, IframeTab, SidebarTab } from './components/ShellNavBar';
 import { TokensTab } from './components/TokensTab';
@@ -13,7 +13,7 @@ import { NotEditableDialog } from './components/NotEditableDialog';
 import { ToastViewport } from './components/ToastViewport';
 import { GitMenu } from './components/GitMenu';
 import { GitSyncBanner } from './components/GitSyncBanner';
-import { CrashLoadingOverlay } from './components/CrashLoadingOverlay';
+import { CrashLoadingOverlay, CrashErrorOverlay } from './components/CrashLoadingOverlay';
 import { useGitSync } from './hooks/useGitSync';
 import { useIframeBridge } from './hooks/useIframeBridge';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
@@ -37,6 +37,24 @@ const VITE_ERROR_GRACE_MS = 10_000;
 // loading state) · error: crash outlived the grace period (full error shown).
 type ViteErrorPhase = 'none' | 'pending' | 'error';
 
+// The shell itself is a Vite client, so error payloads pushed over the HMR
+// websocket create a vite-error-overlay in this document too (hidden by
+// shell.css). Read it to recover the error text for the blank-canvas case,
+// where the app iframe has no overlay of its own to show.
+function readOwnViteOverlayError(): string | null {
+  try {
+    const root = (document.querySelector('vite-error-overlay') as HTMLElement & { shadowRoot?: ShadowRoot | null })?.shadowRoot;
+    if (!root) return null;
+    const part = (sel: string) => root.querySelector(sel)?.textContent?.trim() || '';
+    const text = [part('.plugin'), part('.message-body'), part('.file'), part('.frame')]
+      .filter(Boolean)
+      .join('\n\n');
+    return text || null;
+  } catch {
+    return null;
+  }
+}
+
 function parseTabParam(search: string): IframeTab {
   const tab = new URLSearchParams(search).get('tab');
   return tab === 'components' || tab === 'sketchpad' ? tab : 'app';
@@ -54,6 +72,11 @@ export const ProtovibeApp: React.FC = () => {
   );
   const [activeSidebarTab, setActiveSidebarTab] = useState<SidebarTab>('design');
   const [viteErrorPhase, setViteErrorPhase] = useState<ViteErrorPhase>('none');
+  // A crash that leaves the canvas blank (failed module load on a fresh page,
+  // no vite-error-overlay in the iframe) — the shell must render the final
+  // error itself, using whatever detail it can recover.
+  const [moduleLoadError, setModuleLoadError] = useState(false);
+  const [viteErrorDetail, setViteErrorDetail] = useState<string | null>(null);
   // Ref mirror so the (once-registered) message handler and the grace timer
   // can read the current phase without re-subscribing on every change.
   const viteErrorPhaseRef = useRef<ViteErrorPhase>('none');
@@ -303,17 +326,27 @@ export const ProtovibeApp: React.FC = () => {
   // surface the full error if no HMR update clears it within the grace period.
   useEffect(() => {
     const handler = (e: MessageEvent) => {
-      if (e.data?.type === 'PV_VITE_ERROR' && viteErrorPhaseRef.current === 'none') {
-        setViteError('pending');
-        clearViteErrorTimer();
-        viteErrorTimerRef.current = window.setTimeout(() => {
-          viteErrorTimerRef.current = null;
-          if (viteErrorPhaseRef.current === 'pending') setViteError('error');
-        }, VITE_ERROR_GRACE_MS);
+      if (e.data?.type === 'PV_VITE_ERROR') {
+        // Last write wins: an overlay appearing in the iframe means the canvas
+        // is no longer blank, a failed module load means it is.
+        if (typeof e.data.moduleLoadError === 'boolean') setModuleLoadError(e.data.moduleLoadError);
+        if (viteErrorPhaseRef.current === 'none') {
+          setViteError('pending');
+          clearViteErrorTimer();
+          viteErrorTimerRef.current = window.setTimeout(() => {
+            viteErrorTimerRef.current = null;
+            if (viteErrorPhaseRef.current === 'pending') {
+              setViteErrorDetail(readOwnViteOverlayError());
+              setViteError('error');
+            }
+          }, VITE_ERROR_GRACE_MS);
+        }
       }
       if (e.data?.type === 'PV_VITE_ERROR_CLEARED') {
         clearViteErrorTimer();
         setViteError('none');
+        setModuleLoadError(false);
+        setViteErrorDetail(null);
       }
     };
     window.addEventListener('message', handler);
@@ -395,6 +428,20 @@ export const ProtovibeApp: React.FC = () => {
     });
   }, [runLockedMutation]);
 
+  // Reload one canvas iframe (used by the crash covers and the error banner).
+  const reloadIframe = useCallback((ref: React.RefObject<HTMLIFrameElement | null>) => {
+    try {
+      ref.current?.contentWindow?.location.reload();
+    } catch {
+      if (ref.current) ref.current.src = ref.current.src; // eslint-disable-line no-self-assign
+    }
+  }, []);
+
+  const activeIframeRef =
+    activeIframeTab === 'sketchpad' ? sketchpadIframeRef :
+    activeIframeTab === 'components' ? componentsIframeRef :
+    appIframeRef;
+
   // Wipe the prototype's persisted state. The clear runs inside the app iframe
   // (see PV_CLEAR_STORAGE in bridge.ts), which then reloads itself.
   const handleClearStorage = () => {
@@ -432,6 +479,20 @@ export const ProtovibeApp: React.FC = () => {
     window.addEventListener('message', handler);
     return () => window.removeEventListener('message', handler);
   }, []);
+
+  // Crash covers rendered over each canvas iframe: the loading state during the
+  // grace period, and the shell-rendered final error when the canvas is blank
+  // (a failed module load leaves no vite-error-overlay to show through to).
+  const renderCrashCover = (ref: React.RefObject<HTMLIFrameElement | null>) => (
+    <>
+      {viteErrorPhase === 'pending' && (
+        <CrashLoadingOverlay onRefresh={() => reloadIframe(ref)} onUndo={handleUndo} />
+      )}
+      {viteErrorPhase === 'error' && moduleLoadError && (
+        <CrashErrorOverlay detail={viteErrorDetail} onRefresh={() => reloadIframe(ref)} onUndo={handleUndo} />
+      )}
+    </>
+  );
 
   // Broadcast theme to all iframes whenever it changes
   useEffect(() => {
@@ -483,6 +544,10 @@ export const ProtovibeApp: React.FC = () => {
             </div>
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: '16px', flexShrink: 0 }}>
+            <button onClick={() => reloadIframe(activeIframeRef)} style={{ background: theme.destructive_default, color: '#fff', border: 'none', padding: '6px 14px', borderRadius: '4px', fontSize: '15px', fontWeight: 600, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '6px' }}>
+              <RefreshCw size={16} />
+              Refresh
+            </button>
             <button onClick={handleUndo} style={{ background: theme.destructive_default, color: '#fff', border: 'none', padding: '6px 14px', borderRadius: '4px', fontSize: '15px', fontWeight: 600, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '6px' }}>
               <Undo2 size={16} />
               Undo
@@ -637,7 +702,7 @@ export const ProtovibeApp: React.FC = () => {
                 }}
                 onLoad={() => handleIframeLoad(appIframeRef)}
               />
-              {viteErrorPhase === 'pending' && <CrashLoadingOverlay onUndo={handleUndo} />}
+              {renderCrashCover(appIframeRef)}
             </div>
           </div>
           <div style={{ flex: 1, display: activeIframeTab === 'sketchpad' ? 'flex' : 'none', minHeight: 0, position: 'relative' }}>
@@ -647,7 +712,7 @@ export const ProtovibeApp: React.FC = () => {
               style={{ flex: 1, border: 'none', minWidth: 0 }}
               onLoad={() => handleIframeLoad(sketchpadIframeRef)}
             />
-            {viteErrorPhase === 'pending' && <CrashLoadingOverlay onUndo={handleUndo} />}
+            {renderCrashCover(sketchpadIframeRef)}
           </div>
           <div style={{ flex: 1, display: activeIframeTab === 'components' ? 'flex' : 'none', minHeight: 0, position: 'relative' }}>
             <iframe
@@ -656,7 +721,7 @@ export const ProtovibeApp: React.FC = () => {
               style={{ flex: 1, border: 'none', minWidth: 0 }}
               onLoad={() => handleIframeLoad(componentsIframeRef)}
             />
-            {viteErrorPhase === 'pending' && <CrashLoadingOverlay onUndo={handleUndo} />}
+            {renderCrashCover(componentsIframeRef)}
           </div>
           <div
             style={{

--- a/protovibe-project-template/plugins/protovibe/src/ui/bridge.ts
+++ b/protovibe-project-template/plugins/protovibe/src/ui/bridge.ts
@@ -605,6 +605,9 @@ function init() {
   // Report the initial error state either way. A document that unloads mid-error
   // (full reload, manual refresh) can never post ERROR_CLEARED for the overlay it
   // took with it, so a fresh healthy load must explicitly clear the shell's state.
+  // Note for the shell: no CLEARED is definitive — vite removes and re-adds the
+  // overlay on every update cycle when a broken JS update rides along with a
+  // successful CSS one — so recovery must always be confirmed with a delay.
   const hasOverlay = !!document.querySelector('vite-error-overlay');
   const hasError = sawModuleLoadError || hasOverlay;
   window.parent.postMessage(

--- a/protovibe-project-template/plugins/protovibe/src/ui/bridge.ts
+++ b/protovibe-project-template/plugins/protovibe/src/ui/bridge.ts
@@ -564,6 +564,24 @@ function handleParentMessage(e: MessageEvent) {
 
 // ─── Init ─────────────────────────────────────────────────────────────────────
 
+// A document that loads while the server has a compile error gets no
+// vite-error-overlay (the overlay only accompanies HMR-pushed errors) — the
+// entry module request just 500s and the page stays blank. Catch failing
+// same-origin script loads so a refresh mid-crash is still reported as one.
+// Registered at module scope: the entry module's error event fires before
+// DOMContentLoaded, so waiting for init() would miss it.
+let sawModuleLoadError = false;
+window.addEventListener('error', (e) => {
+  const target = e.target as HTMLElement | null;
+  if (target?.tagName !== 'SCRIPT') return;
+  const src = (target as HTMLScriptElement).src || '';
+  if (!src.startsWith(window.location.origin)) return;
+  sawModuleLoadError = true;
+  if (window.parent !== window) {
+    window.parent.postMessage({ type: 'PV_VITE_ERROR' }, '*');
+  }
+}, true);
+
 function init() {
   // Skip entirely when the app is opened as a standalone page (not embedded in the
   // Protovibe shell iframe). In that case window.parent === window.
@@ -582,10 +600,14 @@ function init() {
   // covers nested scroll containers as well as the root document.
   window.addEventListener('scroll', () => syncOverlays(), { capture: true, passive: true });
 
-  // Check initial state in case the error is already there
-  if (document.querySelector('vite-error-overlay')) {
-    window.parent.postMessage({ type: 'PV_VITE_ERROR' }, '*');
-  }
+  // Report the initial error state either way. A document that unloads mid-error
+  // (full reload, manual refresh) can never post ERROR_CLEARED for the overlay it
+  // took with it, so a fresh healthy load must explicitly clear the shell's state.
+  const hasError = sawModuleLoadError || !!document.querySelector('vite-error-overlay');
+  window.parent.postMessage(
+    { type: hasError ? 'PV_VITE_ERROR' : 'PV_VITE_ERROR_CLEARED' },
+    '*'
+  );
 
   // Observe DOM for added/removed error overlays
   const observer = new MutationObserver((mutations) => {

--- a/protovibe-project-template/plugins/protovibe/src/ui/bridge.ts
+++ b/protovibe-project-template/plugins/protovibe/src/ui/bridge.ts
@@ -570,6 +570,8 @@ function handleParentMessage(e: MessageEvent) {
 // same-origin script loads so a refresh mid-crash is still reported as one.
 // Registered at module scope: the entry module's error event fires before
 // DOMContentLoaded, so waiting for init() would miss it.
+// `moduleLoadError: true` tells the shell the canvas is blank (no overlay to
+// see through to), so it must render the error itself once the grace elapses.
 let sawModuleLoadError = false;
 window.addEventListener('error', (e) => {
   const target = e.target as HTMLElement | null;
@@ -578,7 +580,7 @@ window.addEventListener('error', (e) => {
   if (!src.startsWith(window.location.origin)) return;
   sawModuleLoadError = true;
   if (window.parent !== window) {
-    window.parent.postMessage({ type: 'PV_VITE_ERROR' }, '*');
+    window.parent.postMessage({ type: 'PV_VITE_ERROR', moduleLoadError: true }, '*');
   }
 }, true);
 
@@ -603,9 +605,12 @@ function init() {
   // Report the initial error state either way. A document that unloads mid-error
   // (full reload, manual refresh) can never post ERROR_CLEARED for the overlay it
   // took with it, so a fresh healthy load must explicitly clear the shell's state.
-  const hasError = sawModuleLoadError || !!document.querySelector('vite-error-overlay');
+  const hasOverlay = !!document.querySelector('vite-error-overlay');
+  const hasError = sawModuleLoadError || hasOverlay;
   window.parent.postMessage(
-    { type: hasError ? 'PV_VITE_ERROR' : 'PV_VITE_ERROR_CLEARED' },
+    hasError
+      ? { type: 'PV_VITE_ERROR', moduleLoadError: sawModuleLoadError && !hasOverlay }
+      : { type: 'PV_VITE_ERROR_CLEARED' },
     '*'
   );
 
@@ -614,7 +619,7 @@ function init() {
     for (const mutation of mutations) {
       for (const node of mutation.addedNodes) {
         if (node.nodeName && (node as HTMLElement).nodeName.toLowerCase() === 'vite-error-overlay') {
-          window.parent.postMessage({ type: 'PV_VITE_ERROR' }, '*');
+          window.parent.postMessage({ type: 'PV_VITE_ERROR', moduleLoadError: false }, '*');
         }
       }
       for (const node of mutation.removedNodes) {

--- a/protovibe-project-template/plugins/protovibe/src/ui/components/CrashLoadingOverlay.tsx
+++ b/protovibe-project-template/plugins/protovibe/src/ui/components/CrashLoadingOverlay.tsx
@@ -1,0 +1,60 @@
+// plugins/protovibe/src/ui/components/CrashLoadingOverlay.tsx
+import React from 'react';
+import { RotateCw, Undo2 } from 'lucide-react';
+import { theme } from '../theme';
+
+const SPIN_KEYFRAMES = '@keyframes pv-crash-spin { to { transform: rotate(360deg); } }';
+
+// Opaque cover shown over the canvas while a Vite crash is inside its grace
+// period (see ProtovibeApp). When an AI agent edits code the app routinely
+// passes through broken states that the next HMR update clears, so this reads
+// as "working" rather than "crashed" — with a small hint that it might be an
+// error, and an Undo escape hatch for when the user's own change caused it.
+export const CrashLoadingOverlay: React.FC<{ onUndo: () => void }> = ({ onUndo }) => (
+  <div
+    style={{
+      position: 'absolute',
+      inset: 0,
+      zIndex: 10,
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 16,
+      background: theme.bg_default,
+    }}
+  >
+    <style>{SPIN_KEYFRAMES}</style>
+    <RotateCw size={28} style={{ color: theme.text_secondary, animation: 'pv-crash-spin 1s linear infinite' }} />
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6, maxWidth: 440, textAlign: 'center', padding: '0 24px' }}>
+      <div style={{ color: theme.text_default, fontSize: 15, fontWeight: 600 }}>
+        Updating your app…
+      </div>
+      <div style={{ color: theme.text_tertiary, fontSize: 13, lineHeight: 1.5 }}>
+        This usually means your AI agent is working on the code — but it could also be an error.
+        If your last change caused this, you can undo it.
+      </div>
+    </div>
+    <button
+      onClick={onUndo}
+      style={{
+        background: theme.bg_tertiary,
+        color: theme.text_default,
+        border: 'none',
+        padding: '6px 14px',
+        borderRadius: '4px',
+        fontSize: 13,
+        fontWeight: 600,
+        cursor: 'pointer',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '6px',
+      }}
+      onMouseEnter={e => (e.currentTarget.style.background = theme.bg_low)}
+      onMouseLeave={e => (e.currentTarget.style.background = theme.bg_tertiary)}
+    >
+      <Undo2 size={14} />
+      Undo last change
+    </button>
+  </div>
+);

--- a/protovibe-project-template/plugins/protovibe/src/ui/components/CrashLoadingOverlay.tsx
+++ b/protovibe-project-template/plugins/protovibe/src/ui/components/CrashLoadingOverlay.tsx
@@ -1,60 +1,115 @@
 // plugins/protovibe/src/ui/components/CrashLoadingOverlay.tsx
 import React from 'react';
-import { RotateCw, Undo2 } from 'lucide-react';
+import { RotateCw, RefreshCw, Undo2 } from 'lucide-react';
 import { theme } from '../theme';
 
 const SPIN_KEYFRAMES = '@keyframes pv-crash-spin { to { transform: rotate(360deg); } }';
+
+const containerStyle: React.CSSProperties = {
+  position: 'absolute',
+  inset: 0,
+  zIndex: 10,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 16,
+  background: theme.bg_default,
+};
+
+const buttonStyle: React.CSSProperties = {
+  background: theme.bg_tertiary,
+  color: theme.text_default,
+  border: 'none',
+  padding: '6px 14px',
+  borderRadius: '4px',
+  fontSize: 13,
+  fontWeight: 600,
+  cursor: 'pointer',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '6px',
+  minWidth: 180,
+};
+
+const CoverButton: React.FC<{ onClick: () => void; children: React.ReactNode }> = ({ onClick, children }) => (
+  <button
+    onClick={onClick}
+    style={buttonStyle}
+    onMouseEnter={e => (e.currentTarget.style.background = theme.bg_low)}
+    onMouseLeave={e => (e.currentTarget.style.background = theme.bg_tertiary)}
+  >
+    {children}
+  </button>
+);
+
+// Refresh sits above Undo: reloading is always safe, undo only applies when the
+// user's own change caused the crash.
+const CoverActions: React.FC<{ onRefresh: () => void; onUndo: () => void }> = ({ onRefresh, onUndo }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'stretch', gap: 8 }}>
+    <CoverButton onClick={onRefresh}><RefreshCw size={14} />Refresh page</CoverButton>
+    <CoverButton onClick={onUndo}><Undo2 size={14} />Undo last change</CoverButton>
+  </div>
+);
 
 // Opaque cover shown over the canvas while a Vite crash is inside its grace
 // period (see ProtovibeApp). When an AI agent edits code the app routinely
 // passes through broken states that the next HMR update clears, so this reads
 // as "working" rather than "crashed" — with a small hint that it might be an
-// error, and an Undo escape hatch for when the user's own change caused it.
-export const CrashLoadingOverlay: React.FC<{ onUndo: () => void }> = ({ onUndo }) => (
-  <div
-    style={{
-      position: 'absolute',
-      inset: 0,
-      zIndex: 10,
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      justifyContent: 'center',
-      gap: 16,
-      background: theme.bg_default,
-    }}
-  >
+// error, and Refresh/Undo escape hatches.
+export const CrashLoadingOverlay: React.FC<{ onRefresh: () => void; onUndo: () => void }> = ({ onRefresh, onUndo }) => (
+  <div style={containerStyle}>
     <style>{SPIN_KEYFRAMES}</style>
     <RotateCw size={28} style={{ color: theme.text_secondary, animation: 'pv-crash-spin 1s linear infinite' }} />
     <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6, maxWidth: 440, textAlign: 'center', padding: '0 24px' }}>
       <div style={{ color: theme.text_default, fontSize: 15, fontWeight: 600 }}>
-        Updating your app…
+        Loading…
       </div>
       <div style={{ color: theme.text_tertiary, fontSize: 13, lineHeight: 1.5 }}>
         This usually means your AI agent is working on the code — but it could also be an error.
         If your last change caused this, you can undo it.
       </div>
     </div>
-    <button
-      onClick={onUndo}
-      style={{
-        background: theme.bg_tertiary,
-        color: theme.text_default,
-        border: 'none',
-        padding: '6px 14px',
-        borderRadius: '4px',
-        fontSize: 13,
-        fontWeight: 600,
-        cursor: 'pointer',
-        display: 'flex',
-        alignItems: 'center',
-        gap: '6px',
-      }}
-      onMouseEnter={e => (e.currentTarget.style.background = theme.bg_low)}
-      onMouseLeave={e => (e.currentTarget.style.background = theme.bg_tertiary)}
-    >
-      <Undo2 size={14} />
-      Undo last change
-    </button>
+    <CoverActions onRefresh={onRefresh} onUndo={onUndo} />
+  </div>
+);
+
+// Final error state for a crash that leaves the canvas blank: a document that
+// loads while the server has a compile error gets no vite-error-overlay, so the
+// shell shows the captured error (or a generic message) itself.
+export const CrashErrorOverlay: React.FC<{ detail: string | null; onRefresh: () => void; onUndo: () => void }> = ({ detail, onRefresh, onUndo }) => (
+  <div style={containerStyle}>
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6, maxWidth: 640, textAlign: 'center', padding: '0 24px' }}>
+      <div style={{ color: theme.destructive_default, fontSize: 15, fontWeight: 600 }}>
+        The app failed to load
+      </div>
+      <div style={{ color: theme.text_tertiary, fontSize: 13, lineHeight: 1.5 }}>
+        {detail
+          ? 'Fix the error below, undo your last change, or ask your coding agent for help.'
+          : 'There is an error in the code. Undo your last change or ask your coding agent for help.'}
+      </div>
+    </div>
+    {detail && (
+      <pre style={{
+        margin: 0,
+        maxWidth: 'min(640px, calc(100% - 48px))',
+        maxHeight: '40%',
+        overflow: 'auto',
+        textAlign: 'left',
+        background: theme.bg_strong,
+        border: `1px solid ${theme.border_default}`,
+        borderRadius: 6,
+        padding: '12px 16px',
+        fontSize: 12,
+        lineHeight: 1.5,
+        color: theme.destructive_default,
+        whiteSpace: 'pre-wrap',
+        wordBreak: 'break-word',
+      }}>
+        {detail}
+      </pre>
+    )}
+    <CoverActions onRefresh={onRefresh} onUndo={onUndo} />
   </div>
 );


### PR DESCRIPTION
When an AI agent edits code, the app routinely passes through broken
states that the next HMR update clears — showing "The app crashed"
immediately reads as a real failure to the user. Instead, a detected
Vite error now covers the canvas with a calm loading state (with a hint
that it may be an error, plus an Undo escape hatch), and only escalates
to the full error state if the error survives a 10-second grace period.

- ProtovibeApp: replace the boolean error banner with a
  none/pending/error phase machine; render CrashLoadingOverlay over the
  canvas while pending, keep the existing banner (+ Vite overlay) for
  the persistent-error phase.
- bridge: report the initial error state on every load so a full reload
  resyncs the shell (a dying document can never post ERROR_CLEARED),
  and detect failing same-origin module scripts — a fresh page load
  while the server has a compile error renders no vite-error-overlay,
  just a blank canvas from the 500'd entry module.
- Add a project verify skill capturing the build/launch/drive recipe.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0122TLoEmy4cvYqGYk3EoA34