### PR TITLE
Add Enter to select children, Shift+Enter to traverse up

### DIFF
--- a/protovibe-project-template/plugins/protovibe/src/ui/hooks/useKeyboardShortcuts.ts
+++ b/protovibe-project-template/plugins/protovibe/src/ui/hooks/useKeyboardShortcuts.ts
@@ -13,6 +13,7 @@ import { openNotEditableDialog } from '../components/NotEditableDialog';
 import {
   getAllowedParent,
   getAllowedChild,
+  getAllowedChildren,
   getAllowedSibling,
 } from '../utils/traversal';
 import { isTypingInput } from '../utils/elementType';
@@ -429,6 +430,21 @@ export function useKeyboardShortcuts() {
       // WASD traversal is bare-key only. When Cmd/Ctrl is held these letters mean
       // something else (e.g. Cmd+S opens the Git sync popover), so don't traverse.
       if (e.metaKey || e.ctrlKey) return;
+
+      // Enter selects all immediate children (multi-select). Shift+Enter
+      // traverses up to the parent, mirroring the "W" key.
+      if (e.key === 'Enter') {
+        if (e.shiftKey) {
+          handleNavigate(getAllowedParent(currentBaseTarget));
+        } else {
+          const children = getAllowedChildren(currentBaseTarget);
+          if (children.length > 0) {
+            e.preventDefault();
+            focusElement(children);
+          }
+        }
+        return;
+      }
 
       const navKey = e.key.toLowerCase();
       if (navKey === 'w') handleNavigate(getAllowedParent(currentBaseTarget));

--- a/protovibe-project-template/plugins/protovibe/src/ui/utils/traversal.ts
+++ b/protovibe-project-template/plugins/protovibe/src/ui/utils/traversal.ts
@@ -109,6 +109,28 @@ export function getAllowedChild(el: HTMLElement): HTMLElement | null {
 }
 
 /**
+ * Collect every immediate allowed child of `el`. Like `getAllowedChild` but
+ * returns all of them instead of the first: for each branch it descends past
+ * non-allowed wrappers and stops at the first allowed element, so a component
+ * root nested inside plain markup is still reached. Descendants below an
+ * already-collected element are not included.
+ */
+export function getAllowedChildren(el: HTMLElement): HTMLElement[] {
+  const results: HTMLElement[] = [];
+  const queue = Array.from(el.children) as HTMLElement[];
+  while (queue.length > 0) {
+    const child = queue.shift()!;
+    if (isElementAllowed(child)) {
+      results.push(child);
+    } else {
+      // Child is not directly allowed — keep searching its subtree
+      queue.push(...(Array.from(child.children) as HTMLElement[]));
+    }
+  }
+  return results;
+}
+
+/**
  * Walk up from `el` (inclusive) and return the first element that satisfies
  * `isElementAllowed`. Equivalent to `el` itself when already allowed, or
  * `getAllowedParent(el)` when not.


### PR DESCRIPTION
Enter selects every immediate allowed child of the focused element as a
multi-selection, and Shift+Enter traverses up to the parent (mirroring the
"W" key). Adds a getAllowedChildren traversal helper that collects all
immediate allowed children instead of just the first.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DLAWC7jGV5TBEGwZfXcxmU