### PR TITLE
Gate inspector source-file navigation on pvConfig registration

### DIFF
--- a/protovibe-project-template/plugins/protovibe/PROTOVIBE_AGENTS.md
+++ b/protovibe-project-template/plugins/protovibe/PROTOVIBE_AGENTS.md
@@ -211,6 +211,36 @@ Never create custom HTML elements (`<button>`, `<input>`) when an existing compo
 
 When creating or editing reusable components in `src/components/ui/`, they must be registered via `pvConfig`.
 
+### Rule: `src/components/ui/` Is Only for Registered "Dumb" Components
+
+`src/components/ui/` is exclusively for presentational ("dumb") components that export a `pvConfig`. Every file you add here MUST export a `pvConfig` — that is how the visual builder discovers it, lists it in the Components playground, and lets the inspector's "Source files" panel jump to it. A file placed here **without** a `pvConfig` has no playground entry, so clicking through to it goes nowhere.
+
+Anything that is not a registered visual-builder component — stateful containers, data-fetching wrappers, layout/page shells, hooks, context providers, or other logic-heavy helpers — MUST live in a different folder (e.g. `src/components/` outside `ui/`, or a feature folder). Never drop unregistered or "smart" components into `src/components/ui/`.
+
+* **❌ BAD: A smart/unregistered component inside `src/components/ui/`**
+
+  ```tsx
+  // src/components/ui/user-dashboard.tsx  ← wrong folder, no pvConfig
+  export function UserDashboard() {
+    const { data } = useUsers();
+    return <div>{/* fetches + renders app data */}</div>;
+  }
+  ```
+
+* **✅ GOOD: Dumb + registered in `ui/`, smart component elsewhere**
+
+  ```tsx
+  // src/components/ui/stat-card.tsx  ← presentational, exports pvConfig
+  export function StatCard({ ...props }) { return <div {...props} data-pv-component-id="StatCard" />; }
+  export const pvConfig = { name: 'StatCard', /* ... */ };
+
+  // src/components/user-dashboard.tsx  ← smart component, outside ui/
+  export function UserDashboard() {
+    const { data } = useUsers();
+    return <StatCard /* ... */ />;
+  }
+  ```
+
 ### Rule: One `pvConfig` Per File
 
 The scanner strictly looks for `export const pvConfig`. You cannot rename it or have multiple configurations in a single file.

--- a/protovibe-project-template/plugins/protovibe/src/ui/components/Tabs.tsx
+++ b/protovibe-project-template/plugins/protovibe/src/ui/components/Tabs.tsx
@@ -52,17 +52,26 @@ const SourceFileButton: React.FC<{
 };
 
 export const Tabs: React.FC = () => {
-  const { sourceDataList, activeSourceId, setActiveSourceId, setActiveModifiers, activeData } = useProtovibe();
+  const { sourceDataList, activeSourceId, setActiveSourceId, setActiveModifiers, activeData, availableComponents } = useProtovibe();
 
   const normalizePath = (filePath: string) => filePath.replace(/\\/g, '/');
-  const isComponentsFolderSource = (filePath: string) => {
-    const normalized = normalizePath(filePath);
-    return /(^|\/)src\/components(\/|$)/.test(normalized);
+  // Reduce a file path or a pvConfig importPath to a comparable stem:
+  // forward slashes, no leading slash, `@/` mapped to `src/`, no extension.
+  const toStem = (p: string) =>
+    normalizePath(p).replace(/^\//, '').replace(/^@\//, 'src/').replace(/\.[^./]+$/, '');
+  // A source is a navigable "Component" only when it is registered in pvConfig
+  // (present in availableComponents), not merely because it lives under
+  // src/components. A file dropped in the components folder without a pvConfig
+  // has no entry in the Components playground, so navigating there would land on
+  // nothing — treat it as a plain source File instead.
+  const isRegisteredComponentSource = (filePath: string) => {
+    if (!filePath) return false;
+    const stem = toStem(filePath);
+    return availableComponents.some((c: any) => c?.importPath && toStem(c.importPath) === stem);
   };
-  const getFileStem = (fileName: string) => fileName.replace(/\.[^.]+$/, '');
-  const hasComponentsFolderSource = sourceDataList.some((source) => isComponentsFolderSource(source.data?.file || ''));
+  const hasComponentSource = sourceDataList.some((source) => isRegisteredComponentSource(source.data?.file || ''));
 
-  if (sourceDataList.length <= 1 && !hasComponentsFolderSource) return null;
+  if (sourceDataList.length <= 1 && !hasComponentSource) return null;
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', background: theme.bg_strong, flexShrink: 0 }}>
@@ -79,7 +88,7 @@ export const Tabs: React.FC = () => {
         const parts = normalizePath(filePath).split('/');
         const fileName = parts.pop() || 'Unknown';
         
-        const isCompFolder = isComponentsFolderSource(filePath);
+        const isCompFolder = isRegisteredComponentSource(filePath);
         const locationText = isCompFolder ? 'Component' : 'File';
         const displayName = fileName;
 


### PR DESCRIPTION
The inspector's "Source files" panel treated any source under src/components
as a navigable "Component", dispatching pv-open-component-preview to switch to
the Components tab. When a coding agent added a component to the components
folder without a pvConfig, that component had no entry in the Components
playground, so clicking its source tab navigated to nothing.

Navigation (and the purple "Component" styling) is now gated on whether the
source file is actually registered in pvConfig — matched against the
availableComponents list by importPath stem — rather than on its path alone.
Unregistered files in the components folder render as plain source Files.

Also document in PROTOVIBE_AGENTS.md that src/components/ui/ is only for
registered "dumb" components with a pvConfig, and that other (smart/stateful)
components must live in a different folder.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MQPBpcXGsbGY2ySVDdNrsV