### PR TITLE
Split comment threads into one file per message to survive git sync

### DIFF
--- a/protovibe-project-template/plugins/protovibe/PROTOVIBE_AGENTS.md
+++ b/protovibe-project-template/plugins/protovibe/PROTOVIBE_AGENTS.md
@@ -827,31 +827,53 @@ programmatically.
 
 ### Rule: Where comments live
 
-Each comment thread is a standalone JSON file at `src/comments/comment-{id}.json`.
-One file == one thread == one anchored element. These files are normal source
-files and **should be committed to Git** (they are not gitignored). Threads carry
-their own metadata: a triage `status`, the authoring `context` (App / Components /
-Sketchpad, plus the app URL, component name, or sketchpad frame + coordinates),
-and an array of `comments` (each with author name/email, content, and timestamps,
-Git-commit style).
+Each comment thread is a directory at `src/comments/{threadId}/`. One directory
+== one thread == one anchored element. It contains:
+
+* `thread.json` — thread metadata **only** (never any messages): the triage
+  `status`, the authoring `context` (App / Components / Sketchpad, plus the app
+  URL, component name, or sketchpad frame + coordinates), `createdAt`, and
+  `anchorFile`.
+* `{commentId}.json` — **one file per message**, Git-commit style (author
+  name/email, content, timestamps).
+
+Messages are split into their own files on purpose: two people replying to the
+same thread on different machines create two *different new files*, so Git sync
+merges them cleanly instead of a same-file conflict silently dropping one reply.
+These files are normal source files and **should be committed to Git** (they are
+not gitignored).
 
 ```jsonc
+// src/comments/ab12cd34ef/thread.json
 {
   "id": "ab12cd34ef",
   "status": "review",              // optional status id — "minor" | "todo" | "review" | "closed"; omitted while untriaged (labels/colours live in the UI's STATUS_CONFIG)
   "context": { "tab": "app", "file": "src/pages/DashboardPage.tsx", "pathname": "/dashboard" },
-  "comments": [
-    { "id": "c-...", "author": { "name": "Jane", "email": "jane@x.com" },
-      "content": "Tighten this spacing", "createdAt": "2026-06-27T10:00:00.000Z",
-      "seenBy": ["Jane", "Alex"],    // optional read receipts — names that have seen this message; omitted/[] = unseen
-      "suggestions": [               // optional UX-writing suggestions: swap an exact string for a proposed one
-        { "original": "Sign up", "suggested": "Create account" }
-      ] }
-  ],
   "createdAt": "2026-06-27T10:00:00.000Z",
   "anchorFile": "src/pages/DashboardPage.tsx"
 }
+
+// src/comments/ab12cd34ef/c-x7y8z9.json — one message
+{
+  "id": "c-x7y8z9",
+  "author": { "name": "Jane", "email": "jane@x.com" },
+  "content": "Tighten this spacing",
+  "createdAt": "2026-06-27T10:00:00.000Z",
+  "seenBy": ["Jane", "Alex"],      // optional read receipts — names that have seen this message; omitted/[] = unseen
+  "suggestions": [                 // optional UX-writing suggestions: swap an exact string for a proposed one
+    { "original": "Sign up", "suggested": "Create account" }
+  ]
+}
 ```
+
+> **Legacy format.** Older projects store a whole thread as one file,
+> `src/comments/comment-{threadId}.json`, with an inline `comments` array.
+> These are still read (and merged with any split-layout files for the same
+> thread id — a `{threadId}/{commentId}.json` file shadows the inline message
+> with the same id). Never create new threads in this format, and **never
+> append to an inline `comments` array** — that reintroduces the sync conflict.
+> Add new messages as separate `src/comments/{threadId}/{commentId}.json` files
+> even when the thread itself is a legacy file.
 
 ### Rule: The `data-pv-comment-{id}` attribute
 
@@ -865,19 +887,31 @@ collide. Match one with the CSS selector `[data-pv-comment-{id}]`.
 > attribute (which could collide into duplicate attributes). Never write that form.
 
 * **Never remove these attributes** during refactors unless you are deleting the
-  element itself (in which case also delete the matching `src/comments/comment-{id}.json`
-  for every `data-pv-comment-{id}` it carries).
+  element itself (in which case also delete the matching `src/comments/{id}/`
+  directory — and the legacy `src/comments/comment-{id}.json` if present — for
+  every `data-pv-comment-{id}` it carries).
 * When extracting an element into a new component, **preserve every
   `data-pv-comment-{id}` attribute** on the new root element so the comments stay
   anchored.
 
 ### Rule: Editing comments programmatically
 
-To add or resolve comments on the user's behalf, edit the
-`src/comments/comment-{id}.json` files directly (append to `comments`, change
-`status`, etc.). To anchor a brand-new thread, both create the JSON file **and**
-add the valueless `data-pv-comment-{id}` attribute to the target element so the two
-stay in sync. Do not edit these files unless the user asks you to.
+To add or resolve comments on the user's behalf, work file-per-message:
+
+* **Add a message / reply**: create a new `src/comments/{threadId}/{commentId}.json`
+  file (random id, e.g. `c-` + 8 lowercase alphanumerics). Never rewrite an
+  existing message file to append, and never append to a legacy file's inline
+  `comments` array.
+* **Change a thread's status**: edit `src/comments/{threadId}/thread.json`. For
+  a legacy thread that has no directory yet, create the directory and write a
+  `thread.json` (copying `id`, `context`, `createdAt`, `anchorFile` from the
+  legacy file) with the new `status` — once `thread.json` exists it is
+  authoritative for metadata.
+* **Anchor a brand-new thread**: create `src/comments/{threadId}/` with
+  `thread.json` + the first message file, **and** add the valueless
+  `data-pv-comment-{id}` attribute to the target element so the two stay in sync.
+
+Do not edit these files unless the user asks you to.
 
 ### Rule: Wording suggestions are advisory, not source edits
 

--- a/protovibe-project-template/plugins/protovibe/src/backend/comments-server.ts
+++ b/protovibe-project-template/plugins/protovibe/src/backend/comments-server.ts
@@ -1,12 +1,28 @@
 // plugins/protovibe/src/backend/comments-server.ts
 // Backend endpoints for the Comments & Notes feature.
 //
-// Each thread is a standalone JSON file at src/comments/comment-{id}.json so
-// that threads never collide on merge and are trivially committable to Git.
-// Undo/redo is handled the same way the inspector handles prop edits: the UI
-// calls /__take-snapshot (capturing the source file and — for creation — the
-// not-yet-existing thread file as empty) BEFORE invoking these mutators, so
-// the standard undo stack restores both the attribute and the file together.
+// Storage is designed around git sync's last-write-wins conflict handling
+// (git-server.ts rebases with `-X theirs`): anything two people can do
+// concurrently must land in *different files*, or one side's write is lost.
+//
+//   Split layout (everything new):
+//     src/comments/{threadId}/thread.json      — metadata only, no messages
+//     src/comments/{threadId}/{commentId}.json — one file per message
+//   Two concurrent replies are two new files with random names — a git sync
+//   merges them cleanly instead of a same-file conflict silently dropping one.
+//
+//   Legacy layout (read-compat): src/comments/comment-{threadId}.json — the
+//   whole thread with an inline `comments` array. Still read and merged with
+//   any split-layout files for the same id (a split message file shadows the
+//   inline copy with the same id). Never rewritten, with one exception:
+//   deleting an inline message, since a removal can't be expressed as a new
+//   file. Edits and read receipts on legacy messages are written as split
+//   overlay files instead, so the legacy file stays byte-stable across
+//   machines and can't conflict.
+//
+// Undo/redo: thread data is intentionally excluded from the snapshot stack
+// (see CommentsTab's mutateThreadFile) — the UI snapshots only the anchored
+// source file, so stepping through code history never drops a reply.
 
 import fs from 'fs';
 import path from 'path';
@@ -14,8 +30,8 @@ import sharp from 'sharp';
 import { Connect, ViteDevServer } from 'vite';
 import type { CommentThread, CommentItem } from '../shared/comments';
 import {
-  normalizeStatus, threadFileName, COMMENTS_DIR_REL,
-  COMMENT_ATTACHMENTS_DIR_REL, commentIdAttr,
+  normalizeStatus, threadFileName, commentFileName, THREAD_META_FILE,
+  COMMENTS_DIR_REL, COMMENT_ATTACHMENTS_DIR_REL, commentIdAttr,
 } from '../shared/comments';
 
 const COMMENTS_DIR = path.resolve(process.cwd(), COMMENTS_DIR_REL);
@@ -54,8 +70,45 @@ function sendError(res: any, msg: string, status = 400): void {
 
 // ─── thread file IO ──────────────────────────────────────────────────────────
 
-function threadPath(id: string): string {
+/** Thread metadata as persisted in thread.json — a thread minus its messages. */
+type ThreadMeta = Omit<CommentThread, 'comments'>;
+
+// Thread and comment ids come from the client and end up in filesystem paths.
+// Generated ids are short lowercase alphanumerics (optionally `c-` prefixed);
+// anything else — path separators, dots, the reserved thread.json/attachments
+// names — is rejected rather than sanitized.
+const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
+function safeId(raw: unknown): string | null {
+  const id = String(raw ?? '');
+  if (!SAFE_ID.test(id)) return null;
+  if (id === 'thread' || id === 'attachments') return null;
+  return id;
+}
+
+/** Legacy single-file thread: src/comments/comment-{id}.json (read-compat). */
+function legacyThreadPath(id: string): string {
   return path.join(COMMENTS_DIR, threadFileName(id));
+}
+
+/** Split-layout thread directory: src/comments/{id}/ */
+function threadDir(id: string): string {
+  return path.join(COMMENTS_DIR, id);
+}
+
+function threadMetaPath(id: string): string {
+  return path.join(threadDir(id), THREAD_META_FILE);
+}
+
+function commentPath(threadId: string, commentId: string): string {
+  return path.join(threadDir(threadId), commentFileName(commentId));
+}
+
+function readJson<T>(p: string): T | null {
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf-8')) as T;
+  } catch {
+    return null;
+  }
 }
 
 // Normalize a freshly-parsed thread so the rest of the app only ever sees
@@ -67,31 +120,83 @@ function hydrateThread(thread: CommentThread): CommentThread {
   return thread;
 }
 
-function readThread(id: string): CommentThread | null {
-  const p = threadPath(id);
-  if (!fs.existsSync(p)) return null;
-  try {
-    return hydrateThread(JSON.parse(fs.readFileSync(p, 'utf-8')) as CommentThread);
-  } catch {
-    return null;
-  }
+function metaOf(thread: CommentThread | ThreadMeta): ThreadMeta {
+  const { comments: _drop, ...meta } = thread as CommentThread;
+  return meta;
 }
 
-function writeThread(thread: CommentThread): void {
-  fs.mkdirSync(COMMENTS_DIR, { recursive: true });
-  fs.writeFileSync(threadPath(thread.id), JSON.stringify(thread, null, 2), 'utf-8');
+/**
+ * Assemble a thread from every file that contributes to it: the legacy
+ * single-file thread (if any), the split-layout thread.json (if any), and the
+ * split-layout per-message files. Once thread.json exists it is authoritative
+ * for metadata — falling back to the legacy file's status would resurrect a
+ * status that was cleared after the split. Messages merge by id (a split file
+ * shadows a legacy inline copy) and sort chronologically.
+ */
+function readThread(id: string): CommentThread | null {
+  const legacy = readJson<CommentThread>(legacyThreadPath(id));
+  const dir = threadDir(id);
+  let dirEntries: string[] | null = null;
+  try {
+    dirEntries = fs.readdirSync(dir);
+  } catch {
+    // no split-layout directory
+  }
+  if (!legacy && dirEntries == null) return null;
+
+  const meta: ThreadMeta | null =
+    (dirEntries != null ? readJson<ThreadMeta>(threadMetaPath(id)) : null) ??
+    (legacy ? metaOf(legacy) : null);
+
+  const comments: CommentItem[] = Array.isArray(legacy?.comments) ? [...legacy!.comments] : [];
+  for (const f of dirEntries ?? []) {
+    if (f === THREAD_META_FILE || !f.endsWith('.json')) continue;
+    const item = readJson<CommentItem>(path.join(dir, f));
+    if (!item || !item.id) continue;
+    const at = comments.findIndex((c) => c.id === item.id);
+    if (at >= 0) comments[at] = item; // split overlay shadows the inline copy
+    else comments.push(item);
+  }
+  // ISO timestamps sort lexicographically; the sort is stable so equal stamps
+  // keep legacy array order.
+  comments.sort((a, b) => (a.createdAt || '').localeCompare(b.createdAt || ''));
+
+  if (!meta) {
+    // Split directory without thread.json (e.g. a half-finished sync) — keep
+    // the messages readable rather than dropping the whole thread.
+    if (!comments.length) return null;
+    return hydrateThread({ id, context: { tab: 'app' }, comments, createdAt: comments[0].createdAt || '' });
+  }
+  // `id` last: the filesystem name wins over whatever the JSON claims, so
+  // writes always land back in the same files reads came from.
+  return hydrateThread({ ...meta, comments, id });
+}
+
+function writeThreadMeta(meta: ThreadMeta): void {
+  fs.mkdirSync(threadDir(meta.id), { recursive: true });
+  fs.writeFileSync(threadMetaPath(meta.id), JSON.stringify(metaOf(meta), null, 2), 'utf-8');
+}
+
+function writeCommentFile(threadId: string, item: CommentItem): void {
+  fs.mkdirSync(threadDir(threadId), { recursive: true });
+  fs.writeFileSync(commentPath(threadId, item.id), JSON.stringify(item, null, 2), 'utf-8');
 }
 
 function listThreads(): CommentThread[] {
   if (!fs.existsSync(COMMENTS_DIR)) return [];
-  const threads: CommentThread[] = [];
-  for (const f of fs.readdirSync(COMMENTS_DIR)) {
-    if (!f.startsWith('comment-') || !f.endsWith('.json')) continue;
-    try {
-      threads.push(hydrateThread(JSON.parse(fs.readFileSync(path.join(COMMENTS_DIR, f), 'utf-8'))));
-    } catch {
-      // skip malformed file
+  // Union of both layouts' thread ids: split directories + legacy files.
+  const ids = new Set<string>();
+  for (const entry of fs.readdirSync(COMMENTS_DIR, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (entry.name !== 'attachments') ids.add(entry.name);
+    } else if (entry.name.startsWith('comment-') && entry.name.endsWith('.json')) {
+      ids.add(entry.name.slice('comment-'.length, -'.json'.length));
     }
+  }
+  const threads: CommentThread[] = [];
+  for (const id of ids) {
+    const t = readThread(id);
+    if (t) threads.push(t);
   }
   // Newest first.
   threads.sort((a, b) => (b.createdAt || '').localeCompare(a.createdAt || ''));
@@ -227,7 +332,8 @@ export const handleCommentCreateThread: Connect.NextHandleFunction = async (req,
   try {
     const { file, nameEnd, thread } = await parseBody(req);
     if (!file) return sendError(res, 'No file provided');
-    if (!thread || !thread.id) return sendError(res, 'Missing thread data');
+    const threadId = safeId(thread?.id);
+    if (!thread || !threadId) return sendError(res, 'Missing thread data');
     if (!Array.isArray(nameEnd) || nameEnd.length !== 2) {
       return sendError(res, 'Missing element location (nameEnd)');
     }
@@ -240,24 +346,30 @@ export const handleCommentCreateThread: Connect.NextHandleFunction = async (req,
     // Each thread is its own valueless attribute, so there is no list to merge
     // into: either this id is already present (idempotent), or we inject a fresh
     // `data-pv-comment-{id}` at nameEnd — even when the element anchors others.
-    const alreadyInjected = idAttrRegex(thread.id).test(original);
+    const alreadyInjected = idAttrRegex(threadId).test(original);
     const newSource = alreadyInjected
       ? original
-      : injectAttribute(original, nameEnd as [number, number], thread.id);
+      : injectAttribute(original, nameEnd as [number, number], threadId);
+
+    // Message ids become filenames — regenerate any that aren't filename-safe.
+    const comments: CommentItem[] = (Array.isArray(thread.comments) ? thread.comments : [])
+      .map((c: CommentItem) => ({ ...c, id: safeId(c?.id) || `c-${Math.random().toString(36).substring(2, 10)}` }));
 
     const fullThread: CommentThread = {
-      id: thread.id,
+      id: threadId,
       // Threads start untriaged; a status is only set once a reviewer picks one.
       ...(normalizeStatus(thread.status) ? { status: normalizeStatus(thread.status) } : {}),
       context: { tab: 'app', ...(thread.context || {}), file },
-      comments: Array.isArray(thread.comments) ? thread.comments : [],
+      comments,
       createdAt: thread.createdAt || new Date().toISOString(),
       anchorFile: file,
     };
     enrichSketchpadContext(fullThread);
 
-    // Write JSON first, then source (see header note).
-    writeThread(fullThread);
+    // Write JSON first (split layout: metadata + one file per message), then
+    // source — a JSON write failure never leaves an orphaned attribute.
+    writeThreadMeta(metaOf(fullThread));
+    for (const c of fullThread.comments) writeCommentFile(threadId, c);
     fs.writeFileSync(absolutePath, newSource, 'utf-8');
 
     sendJson(res, { success: true, thread: fullThread });
@@ -266,10 +378,14 @@ export const handleCommentCreateThread: Connect.NextHandleFunction = async (req,
   }
 };
 
-// POST { threadId, comment: CommentItem }  → append a reply
+// POST { threadId, comment: CommentItem }  → append a reply.
+// The reply is written as its OWN file ({threadId}/{commentId}.json) and no
+// existing file is touched — this is what makes two people replying to the
+// same thread on different machines merge cleanly through git sync.
 export const handleCommentReply: Connect.NextHandleFunction = async (req, res) => {
   try {
-    const { threadId, comment } = await parseBody(req);
+    const { threadId: rawThreadId, comment } = await parseBody(req);
+    const threadId = safeId(rawThreadId);
     const attachments = Array.isArray(comment?.attachments) ? comment.attachments.filter((a: unknown) => typeof a === 'string') : [];
     const suggestions = sanitizeSuggestions(comment?.suggestions);
     const hasBody = (comment?.content && String(comment.content).trim()) || attachments.length > 0 || suggestions.length > 0;
@@ -279,15 +395,15 @@ export const handleCommentReply: Connect.NextHandleFunction = async (req, res) =
     if (!thread) return sendError(res, 'Thread not found', 404);
 
     const item: CommentItem = {
-      id: comment.id || `c-${Math.random().toString(36).substring(2, 10)}`,
+      id: safeId(comment.id) || `c-${Math.random().toString(36).substring(2, 10)}`,
       author: { name: comment.author?.name || 'Anonymous', email: comment.author?.email || '' },
       content: String(comment.content || ''),
       createdAt: comment.createdAt || new Date().toISOString(),
       ...(attachments.length ? { attachments } : {}),
       ...(suggestions.length ? { suggestions } : {}),
     };
+    writeCommentFile(threadId, item);
     thread.comments.push(item);
-    writeThread(thread);
 
     sendJson(res, { success: true, thread });
   } catch (err) {
@@ -301,7 +417,9 @@ export const handleCommentReply: Connect.NextHandleFunction = async (req, res) =
 export const handleCommentEdit: Connect.NextHandleFunction = async (req, res) => {
   try {
     const body = await parseBody(req);
-    const { threadId, commentId, content } = body;
+    const threadId = safeId(body.threadId);
+    const commentId = safeId(body.commentId);
+    const { content } = body;
     if (!threadId || !commentId || content == null) return sendError(res, 'threadId, commentId and content required');
 
     const thread = readThread(threadId);
@@ -319,7 +437,10 @@ export const handleCommentEdit: Connect.NextHandleFunction = async (req, res) =>
       return sendError(res, 'A comment needs text, an attachment, or a wording suggestion');
     }
     item.updatedAt = new Date().toISOString();
-    writeThread(thread);
+    // Write only this message's file. For a legacy inline message this creates
+    // a split overlay that shadows the inline copy on read — the legacy file
+    // itself stays untouched.
+    writeCommentFile(threadId, item);
 
     sendJson(res, { success: true, thread });
   } catch (err) {
@@ -330,7 +451,9 @@ export const handleCommentEdit: Connect.NextHandleFunction = async (req, res) =>
 // POST { threadId, commentId }  → delete one reply (never the last message)
 export const handleCommentDelete: Connect.NextHandleFunction = async (req, res) => {
   try {
-    const { threadId, commentId } = await parseBody(req);
+    const body = await parseBody(req);
+    const threadId = safeId(body.threadId);
+    const commentId = safeId(body.commentId);
     if (!threadId || !commentId) return sendError(res, 'threadId and commentId required');
 
     const thread = readThread(threadId);
@@ -339,8 +462,19 @@ export const handleCommentDelete: Connect.NextHandleFunction = async (req, res) 
       return sendError(res, 'Cannot delete the only comment — delete the whole thread instead');
     }
 
+    // Remove the split-layout file (the message itself, or an overlay of a
+    // legacy inline message) if there is one.
+    try { fs.unlinkSync(commentPath(threadId, commentId)); } catch {}
+    // Deletion is the one mutation a new file can't express: if the message
+    // (also) lives inline in a legacy file, that file must be rewritten —
+    // otherwise the inline copy would resurface once the overlay is gone.
+    const legacy = readJson<CommentThread>(legacyThreadPath(threadId));
+    if (legacy && Array.isArray(legacy.comments) && legacy.comments.some((c) => c.id === commentId)) {
+      legacy.comments = legacy.comments.filter((c) => c.id !== commentId);
+      fs.writeFileSync(legacyThreadPath(threadId), JSON.stringify(legacy, null, 2), 'utf-8');
+    }
+
     thread.comments = thread.comments.filter((c) => c.id !== commentId);
-    writeThread(thread);
     sendJson(res, { success: true, thread });
   } catch (err) {
     sendError(res, String(err), 500);
@@ -351,7 +485,8 @@ export const handleCommentDelete: Connect.NextHandleFunction = async (req, res) 
 // A null/empty status clears the field, returning the thread to untriaged.
 export const handleCommentUpdateStatus: Connect.NextHandleFunction = async (req, res) => {
   try {
-    const { threadId, status } = await parseBody(req);
+    const { threadId: rawThreadId, status } = await parseBody(req);
+    const threadId = safeId(rawThreadId);
     if (!threadId) return sendError(res, 'threadId required');
 
     const thread = readThread(threadId);
@@ -364,7 +499,9 @@ export const handleCommentUpdateStatus: Connect.NextHandleFunction = async (req,
       if (!normalized) return sendError(res, 'valid status required');
       thread.status = normalized;
     }
-    writeThread(thread);
+    // Metadata lands in thread.json; for a legacy-only thread this creates the
+    // split directory and thread.json becomes authoritative from here on.
+    writeThreadMeta(metaOf(thread));
 
     sendJson(res, { success: true, thread });
   } catch (err) {
@@ -379,7 +516,8 @@ export const handleCommentUpdateStatus: Connect.NextHandleFunction = async (req,
 // opening a thread never lands an entry on the undo stack.
 export const handleCommentSetSeen: Connect.NextHandleFunction = async (req, res) => {
   try {
-    const { threadId, commentId, name, seen } = await parseBody(req);
+    const { threadId: rawThreadId, commentId, name, seen } = await parseBody(req);
+    const threadId = safeId(rawThreadId);
     if (!threadId || !name) return sendError(res, 'threadId and name required');
 
     const thread = readThread(threadId);
@@ -392,10 +530,13 @@ export const handleCommentSetSeen: Connect.NextHandleFunction = async (req, res)
       // empty array is respected as-is (e.g. the author marked their own unread).
       const base = Array.isArray(c.seenBy) ? c.seenBy : (c.author?.name ? [c.author.name] : []);
       const set = new Set(base);
+      // Only touch messages whose receipts actually changed — a no-op receipt
+      // must not churn files (and git diffs) on every thread open.
+      const changed = !!seen !== set.has(name);
       if (seen) set.add(name); else set.delete(name);
       c.seenBy = Array.from(set);
+      if (changed && safeId(c.id)) writeCommentFile(threadId, c);
     }
-    writeThread(thread);
 
     sendJson(res, { success: true, thread });
   } catch (err) {
@@ -411,14 +552,16 @@ export const handleCommentMarkAllRead: Connect.NextHandleFunction = async (req, 
 
     const threads = listThreads();
     for (const t of threads) {
-      let changed = false;
       for (const c of t.comments) {
         const base = Array.isArray(c.seenBy) ? c.seenBy : (c.author?.name ? [c.author.name] : []);
         const set = new Set(base);
-        if (!set.has(name)) { set.add(name); changed = true; }
+        const changed = !set.has(name);
+        set.add(name);
         c.seenBy = Array.from(set);
+        // Per-message writes (split layout / legacy overlay); untouched
+        // messages keep their files byte-identical.
+        if (changed && safeId(c.id)) writeCommentFile(t.id, c);
       }
-      if (changed) writeThread(t);
     }
 
     sendJson(res, { success: true, threads });
@@ -463,10 +606,12 @@ export const handleCommentUploadAttachment: Connect.NextHandleFunction = async (
   }
 };
 
-// POST { threadId }  → remove the anchor attribute from source + delete the file
+// POST { threadId }  → remove the anchor attribute from source + delete the
+// thread's files in both layouts (split directory and/or legacy file).
 export const handleCommentDeleteThread: Connect.NextHandleFunction = async (req, res) => {
   try {
-    const { threadId } = await parseBody(req);
+    const { threadId: rawThreadId } = await parseBody(req);
+    const threadId = safeId(rawThreadId);
     if (!threadId) return sendError(res, 'threadId required');
 
     const thread = readThread(threadId);
@@ -483,8 +628,9 @@ export const handleCommentDeleteThread: Connect.NextHandleFunction = async (req,
       }
     }
 
-    const p = threadPath(threadId);
-    if (fs.existsSync(p)) fs.unlinkSync(p);
+    const legacy = legacyThreadPath(threadId);
+    if (fs.existsSync(legacy)) fs.unlinkSync(legacy);
+    fs.rmSync(threadDir(threadId), { recursive: true, force: true });
 
     sendJson(res, { success: true });
   } catch (err) {

--- a/protovibe-project-template/plugins/protovibe/src/shared/comments.ts
+++ b/protovibe-project-template/plugins/protovibe/src/shared/comments.ts
@@ -114,7 +114,7 @@ export interface CommentItem {
   seenBy?: string[];
 }
 
-/** One thread === one `comment-{id}.json` file === one `data-pv-comment-{id}` attribute. */
+/** One thread === one `src/comments/{id}/` directory === one `data-pv-comment-{id}` attribute. */
 export interface CommentThread {
   /** Anchored on its element as a valueless `data-pv-comment-{id}` attribute. */
   id: string;
@@ -168,13 +168,31 @@ export function readCommentIds(attrNames: readonly string[]): string[] {
   return ids;
 }
 
-/** Directory (relative to project root) where thread files are committed. */
+/**
+ * Storage layout. Each thread is a directory, `src/comments/{threadId}/`,
+ * holding `thread.json` (metadata only — id, status, context, createdAt,
+ * anchorFile; no messages) plus one `{commentId}.json` file per message.
+ * Messages are split into their own files so that two people replying to the
+ * same thread on different machines produce two *new* files — git sync then
+ * merges them cleanly instead of a same-file conflict dropping one reply.
+ *
+ * Legacy layout (still read, never written): a single `comment-{threadId}.json`
+ * file holding the whole thread with an inline `comments` array.
+ */
 export const COMMENTS_DIR_REL = 'src/comments';
 
 /** Subdirectory (relative to project root) where comment image attachments live. */
 export const COMMENT_ATTACHMENTS_DIR_REL = 'src/comments/attachments';
 
-/** Filename for a given thread id. */
+/** Metadata filename inside a thread's directory (split layout). */
+export const THREAD_META_FILE = 'thread.json';
+
+/** Filename for a single message inside a thread's directory (split layout). */
+export function commentFileName(commentId: string): string {
+  return `${commentId}.json`;
+}
+
+/** Filename of a legacy single-file thread (read-compat only). */
 export function threadFileName(id: string): string {
   return `comment-${id}.json`;
 }


### PR DESCRIPTION
Comment threads were stored as a single JSON file per thread, so two
people replying to the same thread on different machines edited the same
region of the same file. Git sync resolves same-file conflicts with
last-write-wins (rebase -X theirs), which silently dropped one of the
replies.

New split layout: src/comments/{threadId}/thread.json holds metadata
only, and each message is its own {commentId}.json file. Concurrent
replies are now two different new files, which git merges cleanly.

Legacy single-file threads (comment-{id}.json) remain fully readable and
are merged with any split-layout files for the same id. They are never
rewritten except for message deletion: edits and read receipts on legacy
messages are written as split overlay files that shadow the inline copy
by id, and status changes migrate metadata into an authoritative
thread.json. Thread/comment ids are now validated before being used as
filenames.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QivN8Dj95WqAFzomVGnRpz