### PR TITLE
Keep bottom bar full-width when Elements panel is open

### DIFF
--- a/protovibe-project-template/plugins/protovibe/src/ui/ProtovibeApp.tsx
+++ b/protovibe-project-template/plugins/protovibe/src/ui/ProtovibeApp.tsx
@@ -654,13 +654,18 @@ export const ProtovibeApp: React.FC = () => {
         </div>
       )}
       <div style={{ flex: 1, display: 'flex', overflow: 'hidden', minHeight: 0 }}>
-        {elementsPanelOpen && (
-          <ElementsPanel
-            activeIframeTab={activeIframeTab}
-            iframeRef={activeIframeRef}
-          />
-        )}
         <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, overflow: 'hidden' }}>
+          {/* Row holding the elements panel next to the canvas. The panel only
+              squeezes the iframe here — the bottom bar below spans full width. */}
+          <div style={{ flex: 1, display: 'flex', minHeight: 0, minWidth: 0, overflow: 'hidden' }}>
+            {elementsPanelOpen && (
+              <ElementsPanel
+                activeIframeTab={activeIframeTab}
+                iframeRef={activeIframeRef}
+                onClose={toggleElementsPanel}
+              />
+            )}
+            <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, minHeight: 0, overflow: 'hidden' }}>
           <div style={{ flex: 1, display: activeIframeTab === 'app' ? 'flex' : 'none', minHeight: 0, flexDirection: 'column' }}>
             <div
               style={{
@@ -819,6 +824,8 @@ export const ProtovibeApp: React.FC = () => {
               onLoad={() => handleIframeLoad(componentsIframeRef)}
             />
             {renderCrashCover(componentsIframeRef)}
+          </div>
+            </div>
           </div>
           <div
             style={{

--- a/protovibe-project-template/plugins/protovibe/src/ui/components/ElementsPanel.tsx
+++ b/protovibe-project-template/plugins/protovibe/src/ui/components/ElementsPanel.tsx
@@ -3,7 +3,7 @@
 // canvas hover outline (via PV_TREE_HOVER — see bridge.ts), clicking selects
 // the element through the same focusElement path a canvas click uses.
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ChevronRight, ChevronsDownUp, ChevronsUpDown, ListTree, X } from 'lucide-react';
+import { ChevronRight, ChevronsDownUp, ChevronsUpDown, X } from 'lucide-react';
 import { useProtovibe } from '../context/ProtovibeContext';
 import { theme } from '../theme';
 import { isElementAllowed } from '../utils/traversal';
@@ -373,7 +373,6 @@ export const ElementsPanel: React.FC<ElementsPanelProps> = ({ activeIframeTab, i
         }}
       >
         <span style={{ fontWeight: 600, fontSize: 12, color: theme.text_secondary, display: 'flex', alignItems: 'center', gap: 6 }}>
-          <ListTree size={14} />
           Elements
         </span>
         <div style={{ display: 'flex', gap: 2 }}>

--- a/protovibe-project-template/plugins/protovibe/src/ui/components/ElementsPanel.tsx
+++ b/protovibe-project-template/plugins/protovibe/src/ui/components/ElementsPanel.tsx
@@ -3,7 +3,7 @@
 // canvas hover outline (via PV_TREE_HOVER — see bridge.ts), clicking selects
 // the element through the same focusElement path a canvas click uses.
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ChevronRight, ChevronsDownUp, ChevronsUpDown, ListTree } from 'lucide-react';
+import { ChevronRight, ChevronsDownUp, ChevronsUpDown, ListTree, X } from 'lucide-react';
 import { useProtovibe } from '../context/ProtovibeContext';
 import { theme } from '../theme';
 import { isElementAllowed } from '../utils/traversal';
@@ -91,9 +91,10 @@ function ensureRuntimeId(el: HTMLElement): string {
 type ElementsPanelProps = {
   activeIframeTab: IframeTab;
   iframeRef: React.RefObject<HTMLIFrameElement | null>;
+  onClose: () => void;
 };
 
-export const ElementsPanel: React.FC<ElementsPanelProps> = ({ activeIframeTab, iframeRef }) => {
+export const ElementsPanel: React.FC<ElementsPanelProps> = ({ activeIframeTab, iframeRef, onClose }) => {
   const { focusElement, currentBaseTarget } = useProtovibe();
 
   const [roots, setRoots] = useState<TreeNode[]>([]);
@@ -395,6 +396,16 @@ export const ElementsPanel: React.FC<ElementsPanelProps> = ({ activeIframeTab, i
             onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = theme.text_tertiary; }}
           >
             <ChevronsDownUp size={14} />
+          </button>
+          <div style={{ width: 1, height: 16, background: theme.border_default, margin: '0 2px', alignSelf: 'center' }} />
+          <button
+            onClick={onClose}
+            data-tooltip="Close panel"
+            style={headerButtonStyle(true)}
+            onMouseEnter={e => { e.currentTarget.style.background = theme.bg_low; e.currentTarget.style.color = theme.text_secondary; }}
+            onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = theme.text_tertiary; }}
+          >
+            <X size={14} />
           </button>
         </div>
       </div>


### PR DESCRIPTION
The Elements panel sat beside the whole canvas column, so opening it
pushed the bottom bar (light/dark toggle, help) to the right along with
the iframe. Move the panel into a row that wraps only the canvas tabs so
it squeezes the iframe alone, leaving the bottom bar spanning full width.

Also add an X close button in the panel header as another way to close it.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HPJP1BGEStMsTpGdwAZ421