### PR TITLE
Refresh wording-suggestion previews after git sync and edits

### DIFF
--- a/protovibe-project-template/plugins/protovibe/src/ui/components/CommentsTab.tsx
+++ b/protovibe-project-template/plugins/protovibe/src/ui/components/CommentsTab.tsx
@@ -245,20 +245,18 @@ export const CommentsTab: React.FC<CommentsTabProps> = ({ activeIframeTab, isAct
   const [profileOpen, setProfileOpen] = useState(false);
   const pendingActionRef = React.useRef<((author: CommentAuthor) => void) | null>(null);
 
-  // Previews the user had switched on survive a page refresh (the service mirrors
-  // them into localStorage), so the first load reconciles them against what's
-  // actually on disk — a suggestion whose comment was deleted or reworded in the
-  // meantime must not keep rewriting the canvas with no UI to switch it off.
-  const reconciledRef = useRef(false);
-
   const refresh = useCallback(async () => {
     try {
       const next = await fetchCommentThreads();
       setThreads(next);
-      if (!reconciledRef.current) {
-        reconciledRef.current = true;
-        getCopySuggestionPreview().reconcile(savedSuggestionRefs(next));
-      }
+      // Reconcile the live previews against what's now on disk on EVERY refresh,
+      // not just the first. This fires on the initial load, on undo/redo, and —
+      // crucially — after a git sync/pull (via the pv-comments-refresh event) and
+      // after a local edit. A synced or edited suggestion can be added, reworded,
+      // or removed, and the canvas iframe may have reloaded; reconcile prunes gone
+      // previews, follows reworded ones to the new copy, and re-applies them to
+      // the current canvas so the preview never lags behind the saved comment.
+      getCopySuggestionPreview().reconcile(savedSuggestionRefs(next));
     } catch (e) {
       setError(String(e));
     }

--- a/protovibe-project-template/plugins/protovibe/src/ui/utils/copySuggestionPreview.ts
+++ b/protovibe-project-template/plugins/protovibe/src/ui/utils/copySuggestionPreview.ts
@@ -92,8 +92,11 @@ export interface CopySuggestionPreview {
   /** Drop every composer-draft preview (entries with no thread id). */
   clearDrafts(): void;
   /**
-   * Drop persisted previews that no longer match a saved suggestion (its comment
-   * was deleted, or its wording was edited). Call once threads are loaded.
+   * Bring the live previews back in step with what's saved on disk, then re-apply
+   * them to the canvas. Drops previews whose suggestion was deleted, follows one
+   * whose wording was edited to the new copy, and re-applies everything (so a
+   * canvas the git sync / HMR just reloaded gets the previews stamped back on).
+   * Call after every threads load, not only the first.
    */
   reconcile(saved: SavedSuggestionRef[]): void;
   /** Subscribe to registry changes; returns an unsubscribe fn. */
@@ -405,17 +408,42 @@ function createService(): CopySuggestionPreview {
   };
 
   const reconcile = (saved: SavedSuggestionRef[]) => {
-    const valid = new Set(saved.map((s) =>
-      [s.threadId, s.original.trim(), s.suggested, !!s.replaceAll].join(SEP)));
-    let changed = false;
+    // Nothing is previewed → nothing to prune, follow, or re-apply.
+    if (registry.size === 0) return;
+    // Group saved suggestions by the (thread, original) that keys a preview. A
+    // thread can carry several suggestions for the same original (different
+    // comments), so keep the whole list: an existing preview should match one
+    // exactly before we assume it was reworded.
+    const byKey = new Map<string, SavedSuggestionRef[]>();
+    for (const s of saved) {
+      const k = `${s.threadId}${SEP}${s.original.trim()}`;
+      const list = byKey.get(k);
+      if (list) list.push(s); else byKey.set(k, [s]);
+    }
     for (const [key, entry] of Array.from(registry)) {
       if (!entry.threadId) continue;
-      if (!valid.has([entry.threadId, entry.original, entry.suggested, entry.replaceAll].join(SEP))) {
+      const candidates = byKey.get(`${entry.threadId}${SEP}${entry.original}`);
+      if (!candidates) {
+        // The suggestion this preview tracked is gone (its comment or the
+        // suggestion itself was deleted) → drop the stale preview.
         registry.delete(key);
-        changed = true;
+        continue;
+      }
+      // Follow an edit: if no saved suggestion still matches exactly, adopt the
+      // latest saved copy for this original so a reworded suggestion's live
+      // preview updates to the new wording instead of lingering on the old one.
+      const exact = candidates.some((s) => s.suggested === entry.suggested && !!s.replaceAll === entry.replaceAll);
+      if (!exact) {
+        const next = candidates[candidates.length - 1];
+        entry.suggested = next.suggested;
+        entry.replaceAll = !!next.replaceAll;
       }
     }
-    if (changed) refreshCanvas();
+    // Always re-apply, even when the registry itself didn't change: callers run
+    // reconcile after a git sync / undo / edit, any of which can reload the
+    // canvas iframe or leave a recycled text node holding a stale preview, and
+    // rely on this to bring the DOM back in step with the active previews.
+    refreshCanvas();
   };
 
   hydrate();


### PR DESCRIPTION
Wording-suggestion previews were only reconciled against the on-disk
suggestions once (a reconciledRef guard in CommentsTab), and reconcile()
only pruned stale previews and only re-applied the canvas when it deleted
something. So:

- After "Sync with Git" pulled a teammate's reworded/new/removed
  suggestion, the canvas kept showing stale preview text and the preview
  toggle desynced — the only recovery was a full page reload plus
  "Enable preview for all wording suggestions".
- After editing a suggestion locally, an occasional recycled/drifted
  canvas text node kept showing the old preview until the preview was
  toggled off and back on.

Reconcile on every comments refresh instead of just the first, and make
reconcile() follow edits (adopt the new saved copy for a still-previewed
original) and always re-apply the canvas while any preview is active — so
a git sync (via the existing pv-comments-refresh event) and a local edit
both bring the previews back in step with the saved comments without a
manual reload or re-enable.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DXLYbmsPVCg9BKXWgC9paC