### PR TITLE
Add auto-growing textarea support to InspectorInput

### DIFF
--- a/protovibe-project-template/plugins/protovibe/src/ui/components/InspectorInput.tsx
+++ b/protovibe-project-template/plugins/protovibe/src/ui/components/InspectorInput.tsx
@@ -1,5 +1,7 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { theme } from '../theme';
+
+type InspectorFieldElement = HTMLInputElement | HTMLTextAreaElement;
 
 interface InspectorInputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'prefix' | 'onMouseEnter' | 'onMouseLeave'> {
   prefix?: React.ReactNode;
@@ -7,6 +9,14 @@ interface InspectorInputProps extends Omit<React.InputHTMLAttributes<HTMLInputEl
   containerStyle?: React.CSSProperties;
   onMouseEnter?: React.MouseEventHandler<HTMLElement>;
   onMouseLeave?: React.MouseEventHandler<HTMLElement>;
+  /**
+   * Render the field as a textarea that starts at the normal single-line height
+   * and grows to fit its content, so long values (e.g. a paragraph passed to a
+   * text prop) stay fully visible while editing instead of scrolling sideways.
+   * It still behaves like a single-line field: Enter commits and newlines never
+   * make it into the value.
+   */
+  autoGrow?: boolean;
 }
 
 export const InspectorInput: React.FC<InspectorInputProps> = ({
@@ -16,15 +26,20 @@ export const InspectorInput: React.FC<InspectorInputProps> = ({
   onMouseLeave,
   onMouseDown,
   onMouseUp,
+  onKeyDown,
+  onChange,
   style,
   prefix,
   suffix,
   containerStyle,
+  autoGrow = false,
+  type,
   ...props
 }) => {
   const [focused, setFocused] = useState(false);
   const [hovered, setHovered] = useState(false);
-  const inputRef = useRef<HTMLInputElement | null>(null);
+  const inputRef = useRef<InspectorFieldElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const shouldSelectOnMouseUpRef = useRef(false);
 
   // Sync focused state with actual DOM focus to avoid stale visual state
@@ -34,29 +49,77 @@ export const InspectorInput: React.FC<InspectorInputProps> = ({
     }
   });
 
-  const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+  const resizeToContent = useCallback(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
+  }, []);
+
+  // Re-measure whenever the value changes, including on mount so an already
+  // long value opens at full height.
+  useLayoutEffect(() => {
+    if (autoGrow) resizeToContent();
+  }, [autoGrow, props.value, resizeToContent]);
+
+  // Width changes re-wrap the text, which changes how tall it needs to be. The
+  // inspector collapses to 0px while closed, so without this the field would
+  // keep the height it measured at that width.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!autoGrow || !el || typeof ResizeObserver === 'undefined') return;
+    let lastWidth = el.clientWidth;
+    const observer = new ResizeObserver(() => {
+      if (el.clientWidth === lastWidth) return;
+      lastWidth = el.clientWidth;
+      resizeToContent();
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [autoGrow, resizeToContent]);
+
+  const handleFocus = (e: React.FocusEvent<InspectorFieldElement>) => {
     e.target.select();
     setFocused(true);
-    if (onFocus) onFocus(e);
+    if (onFocus) onFocus(e as React.FocusEvent<HTMLInputElement>);
   };
 
-  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+  const handleBlur = (e: React.FocusEvent<InspectorFieldElement>) => {
     setFocused(false);
     shouldSelectOnMouseUpRef.current = false;
-    if (onBlur) onBlur(e);
+    if (onBlur) onBlur(e as React.FocusEvent<HTMLInputElement>);
   };
 
-  const handleMouseDown = (e: React.MouseEvent<HTMLInputElement>) => {
+  const handleMouseDown = (e: React.MouseEvent<InspectorFieldElement>) => {
     shouldSelectOnMouseUpRef.current = document.activeElement !== e.currentTarget;
-    onMouseDown?.(e);
+    onMouseDown?.(e as React.MouseEvent<HTMLInputElement>);
   };
 
-  const handleMouseUp = (e: React.MouseEvent<HTMLInputElement>) => {
+  const handleMouseUp = (e: React.MouseEvent<InspectorFieldElement>) => {
     if (shouldSelectOnMouseUpRef.current) {
       e.currentTarget.select();
       shouldSelectOnMouseUpRef.current = false;
     }
-    onMouseUp?.(e);
+    onMouseUp?.(e as React.MouseEvent<HTMLInputElement>);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<InspectorFieldElement>) => {
+    // A textarea would insert a newline; keep Enter meaning "commit", exactly as
+    // it does for the plain input this replaces.
+    if (autoGrow && e.key === 'Enter') e.preventDefault();
+    onKeyDown?.(e as React.KeyboardEvent<HTMLInputElement>);
+  };
+
+  const handleChange = (e: React.ChangeEvent<InspectorFieldElement>) => {
+    // Pasting multi-line text into an input drops the newlines; do the same here
+    // so the value stays a single line and only wraps visually.
+    if (autoGrow && e.target.value.includes('\n')) {
+      e.target.value = e.target.value.replace(/\r?\n/g, ' ');
+    }
+    onChange?.(e as React.ChangeEvent<HTMLInputElement>);
+    // Controlled fields also re-measure from the effect below; this keeps an
+    // uncontrolled one growing as it is typed into.
+    if (autoGrow) resizeToContent();
   };
 
   const valStr = String(props.value || '').trim();
@@ -76,8 +139,34 @@ export const InspectorInput: React.FC<InspectorInputProps> = ({
     ...style,
   };
 
+  // One 16px line plus 6px of vertical padding fills the container's 22px inner
+  // height exactly, so a single-line field keeps the same 24px row as the input
+  // it replaces and only the wrapped lines add height.
+  const autoGrowStyle: React.CSSProperties = {
+    display: 'block',
+    resize: 'none',
+    overflow: 'hidden',
+    fontFamily: 'inherit',
+    lineHeight: '16px',
+    paddingTop: '3px',
+    paddingBottom: '3px',
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
+  };
+
+  const sharedProps = {
+    ...props,
+    onFocus: handleFocus,
+    onBlur: handleBlur,
+    onMouseDown: handleMouseDown,
+    onMouseUp: handleMouseUp,
+    onKeyDown: handleKeyDown,
+    onChange: handleChange,
+  };
+
   return (
     <div
+      ref={containerRef}
       onMouseEnter={(e) => {
         setHovered(true);
         onMouseEnter?.(e);
@@ -105,15 +194,21 @@ export const InspectorInput: React.FC<InspectorInputProps> = ({
           {prefix}
         </div>
       )}
-      <input
-        ref={inputRef}
-        {...props}
-        onFocus={handleFocus}
-        onBlur={handleBlur}
-        onMouseDown={handleMouseDown}
-        onMouseUp={handleMouseUp}
-        style={inputStyle}
-      />
+      {autoGrow ? (
+        <textarea
+          ref={(el) => { inputRef.current = el; }}
+          {...(sharedProps as unknown as React.TextareaHTMLAttributes<HTMLTextAreaElement>)}
+          rows={1}
+          style={{ ...inputStyle, ...autoGrowStyle }}
+        />
+      ) : (
+        <input
+          ref={(el) => { inputRef.current = el; }}
+          type={type}
+          {...sharedProps}
+          style={inputStyle}
+        />
+      )}
       {suffix && (
         <div style={{ display: 'flex', alignItems: 'center', paddingLeft: '2px', paddingRight: '6px', flexShrink: 0, color: theme.text_tertiary }}>
           {suffix}

--- a/protovibe-project-template/plugins/protovibe/src/ui/components/InspectorKeyValueInput.tsx
+++ b/protovibe-project-template/plugins/protovibe/src/ui/components/InspectorKeyValueInput.tsx
@@ -65,9 +65,11 @@ export const InspectorKeyValueInput: React.FC<InspectorKeyValueInputProps> = ({
 
   const selectBorder = `1px solid ${selectFocused ? theme.accent_default : selectHovered ? theme.border_strong : theme.border_default}`;
 
+  // Text rows grow with their content, so pin the label and the remove button
+  // to the first line instead of centring them against a tall field.
   const rowStyle: React.CSSProperties = {
     display: 'flex',
-    alignItems: 'stretch',
+    alignItems: type === 'text' ? 'flex-start' : 'stretch',
     gap: '4px',
     minHeight: '24px'
   };
@@ -81,7 +83,8 @@ export const InspectorKeyValueInput: React.FC<InspectorKeyValueInputProps> = ({
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
     display: 'flex',
-    alignItems: 'center'
+    alignItems: 'center',
+    minHeight: '24px'
   };
 
   const actionSlotStyle: React.CSSProperties = {
@@ -90,7 +93,8 @@ export const InspectorKeyValueInput: React.FC<InspectorKeyValueInputProps> = ({
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'stretch',
-    alignSelf: 'stretch'
+    alignSelf: type === 'text' ? 'flex-start' : 'stretch',
+    minHeight: '24px'
   };
 
   const removeButtonStyle: React.CSSProperties = {
@@ -164,6 +168,7 @@ export const InspectorKeyValueInput: React.FC<InspectorKeyValueInputProps> = ({
     inputElement = (
       <InspectorInput
         type="text"
+        autoGrow
         value={textValue}
         disabled={disabled}
         onChange={(e) => setTextValue(e.target.value)}

--- a/protovibe-project-template/plugins/protovibe/src/ui/components/InspectorKeyValueInput.tsx
+++ b/protovibe-project-template/plugins/protovibe/src/ui/components/InspectorKeyValueInput.tsx
@@ -87,6 +87,10 @@ export const InspectorKeyValueInput: React.FC<InspectorKeyValueInputProps> = ({
     minHeight: '24px'
   };
 
+  // A text row pins the slot to the first line, so it needs an explicit height
+  // for the button's `height: 100%` to resolve against — without one the button
+  // collapses to the icon and the X rides ~6px above where it sits on the other
+  // row types, which stretch to a full-height row.
   const actionSlotStyle: React.CSSProperties = {
     width: '20px',
     flexShrink: 0,
@@ -94,6 +98,7 @@ export const InspectorKeyValueInput: React.FC<InspectorKeyValueInputProps> = ({
     justifyContent: 'center',
     alignItems: 'stretch',
     alignSelf: type === 'text' ? 'flex-start' : 'stretch',
+    height: type === 'text' ? '24px' : undefined,
     minHeight: '24px'
   };
 


### PR DESCRIPTION
## Summary
Enhanced `InspectorInput` to support an optional auto-growing textarea mode that allows long text values to remain fully visible while editing, instead of scrolling horizontally. The field maintains single-line behavior (Enter commits, newlines are stripped) while visually wrapping content.

## Key Changes

- **New `autoGrow` prop**: When enabled, renders a textarea that automatically grows to fit its content height while maintaining a single-line appearance
- **Unified field type handling**: Introduced `InspectorFieldElement` type to handle both `HTMLInputElement` and `HTMLTextAreaElement` with proper event type casting
- **Content-aware resizing**: 
  - Uses `useLayoutEffect` to measure and resize on value changes (including mount)
  - Uses `ResizeObserver` to re-measure when container width changes (handles inspector collapse/expand)
  - Implements `resizeToContent()` callback to set height based on `scrollHeight`
- **Single-line semantics preserved**:
  - Enter key is prevented from inserting newlines
  - Pasted multi-line text has newlines replaced with spaces
  - Newlines are stripped on change to maintain single-line value
- **Visual styling**: Auto-grow fields use `pre-wrap` and `break-word` for proper text wrapping, with padding adjusted to maintain 24px row height for single-line content
- **Updated `InspectorKeyValueInput`**: Enabled `autoGrow` for text-type fields and adjusted alignment to pin labels/buttons to the first line instead of centering against tall fields

## Implementation Details

- Event handlers (`onKeyDown`, `onChange`) are now extracted and composed into `sharedProps` for cleaner conditional rendering
- Container ref is tracked to enable `ResizeObserver` for width-change detection
- Textarea uses `rows={1}` as a baseline with dynamic height override via inline styles
- Type casting preserves API compatibility while supporting both input and textarea elements

https://claude.ai/code/session_01RJwwsjymYqxK7z5k7E39Cm