### PR TITLE
Store sketchpad camera in localStorage, not the committed registry

### DIFF
--- a/protovibe-project-template/plugins/protovibe/src/backend/sketchpad-server.ts
+++ b/protovibe-project-template/plugins/protovibe/src/backend/sketchpad-server.ts
@@ -74,23 +74,29 @@ interface Frame {
   canvasY: number;
 }
 
-interface ViewState {
-  zoom: number;
-  panX: number;
-  panY: number;
-}
-
 interface SketchpadEntry {
   id: string;
   name: string;
   createdAt: string;
   frames: Frame[];
-  viewState?: ViewState;
 }
 
+// The registry holds shared design data only — it is committed, so anything
+// per-user in it conflicts the moment two people work on the same project. The
+// camera (pan/zoom, last-active sketchpad) therefore lives in the browser's
+// localStorage instead; see ../sketchpads/local-view-state.ts.
 interface Registry {
   sketchpads: SketchpadEntry[];
-  lastActiveSketchpadId?: string;
+}
+
+// Registries written before the camera moved to localStorage carry `viewState`
+// on each sketchpad and a top-level `lastActiveSketchpadId`. Drop them on read
+// so the next write cleans the committed file for everyone.
+function stripLegacyViewState(reg: any): Registry {
+  const sketchpads = Array.isArray(reg?.sketchpads) ? reg.sketchpads : [];
+  return {
+    sketchpads: sketchpads.map(({ viewState, ...entry }: any) => entry as SketchpadEntry),
+  };
 }
 
 function readRegistry(): Registry {
@@ -100,11 +106,11 @@ function readRegistry(): Registry {
     fs.writeFileSync(REGISTRY_PATH, JSON.stringify(initial, null, 2));
     return initial;
   }
-  return JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf-8'));
+  return stripLegacyViewState(JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf-8')));
 }
 
 function writeRegistry(reg: Registry): void {
-  fs.writeFileSync(REGISTRY_PATH, JSON.stringify(reg, null, 2));
+  fs.writeFileSync(REGISTRY_PATH, JSON.stringify(stripLegacyViewState(reg), null, 2));
 }
 
 function slugify(name: string): string {
@@ -327,11 +333,7 @@ export const handleSketchpadDelete: Connect.NextHandleFunction = async (req, res
     );
     snapshotFiles(null, '?tab=sketchpad', `delete ${sp?.name ?? 'sketchpad'}`, 'src/sketchpads/_registry.json', ...framePaths);
 
-    const wasActive = reg.lastActiveSketchpadId === id;
     reg.sketchpads = reg.sketchpads.filter((s) => s.id !== id);
-    if (wasActive) {
-      reg.lastActiveSketchpadId = reg.sketchpads[0]?.id;
-    }
     writeRegistry(reg);
 
     const dirPath = path.join(SKETCHPADS_DIR, id);
@@ -865,38 +867,6 @@ export const handleFrameRead: Connect.NextHandleFunction = async (req, res) => {
     if (!fs.existsSync(filePath)) return sendError(res, 'Frame file not found', 404);
     const content = fs.readFileSync(filePath, 'utf-8');
     sendJson(res, { content });
-  } catch (err) {
-    sendError(res, String(err), 500);
-  }
-};
-
-// Persist per-sketchpad view state (pan/zoom) and last-active id. Does NOT snapshot
-// for undo — view state is ambient and shouldn't generate undo entries.
-export const handleSketchpadUpdateView: Connect.NextHandleFunction = async (req, res) => {
-  try {
-    const { sketchpadId, viewState, makeActive } = await parseBody(req);
-    if (!sketchpadId) return sendError(res, 'sketchpadId required');
-
-    const reg = readRegistry();
-    const sp = reg.sketchpads.find((s) => s.id === sketchpadId);
-    if (!sp) return sendError(res, 'Sketchpad not found', 404);
-
-    if (viewState && typeof viewState === 'object') {
-      const { zoom, panX, panY } = viewState as ViewState;
-      if (
-        typeof zoom === 'number' && isFinite(zoom) &&
-        typeof panX === 'number' && isFinite(panX) &&
-        typeof panY === 'number' && isFinite(panY)
-      ) {
-        sp.viewState = { zoom, panX, panY };
-      }
-    }
-    if (makeActive) {
-      reg.lastActiveSketchpadId = sketchpadId;
-    }
-
-    writeRegistry(reg);
-    sendJson(res, { success: true });
   } catch (err) {
     sendError(res, String(err), 500);
   }

--- a/protovibe-project-template/plugins/protovibe/src/sketchpad-source.ts
+++ b/protovibe-project-template/plugins/protovibe/src/sketchpad-source.ts
@@ -21,7 +21,6 @@ import {
   handleSketchpadDuplicate,
   handleFrameRead,
   handleFramePaste,
-  handleSketchpadUpdateView,
 } from './backend/sketchpad-server';
 
 /**
@@ -35,7 +34,6 @@ export function registerSketchpadMiddleware(server: ViteDevServer) {
   server.middlewares.use('/__sketchpad-duplicate', handleSketchpadDuplicate);
   server.middlewares.use('/__frame-read', handleFrameRead);
   server.middlewares.use('/__frame-paste', handleFramePaste);
-  server.middlewares.use('/__sketchpad-update-view', handleSketchpadUpdateView);
   server.middlewares.use('/__frame-create', handleFrameCreate);
   server.middlewares.use('/__frame-delete', handleFrameDelete);
   server.middlewares.use('/__frame-delete-multi', handleFrameDeleteMulti);

--- a/protovibe-project-template/plugins/protovibe/src/sketchpads/api.ts
+++ b/protovibe-project-template/plugins/protovibe/src/sketchpads/api.ts
@@ -39,28 +39,6 @@ export async function readFrame(sketchpadId: string, frameId: string): Promise<{
   return post('/__frame-read', { sketchpadId, frameId });
 }
 
-export async function updateSketchpadView(
-  sketchpadId: string,
-  opts: { viewState?: { zoom: number; panX: number; panY: number }; makeActive?: boolean },
-  options: { keepalive?: boolean } = {},
-): Promise<void> {
-  const url = '/__sketchpad-update-view';
-  const body = JSON.stringify({ sketchpadId, ...opts });
-  if (options.keepalive && typeof navigator !== 'undefined' && 'sendBeacon' in navigator) {
-    try {
-      const blob = new Blob([body], { type: 'application/json' });
-      navigator.sendBeacon(url, blob);
-      return;
-    } catch {}
-  }
-  await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body,
-    keepalive: options.keepalive,
-  });
-}
-
 export async function pasteFrames(
   targetSketchpadId: string,
   frames: Array<{

--- a/protovibe-project-template/plugins/protovibe/src/sketchpads/components/SketchpadApp.tsx
+++ b/protovibe-project-template/plugins/protovibe/src/sketchpads/components/SketchpadApp.tsx
@@ -6,6 +6,7 @@ import { FrameContainer } from './FrameContainer';
 import { ComponentPalette } from './ComponentPalette';
 import { SketchpadOverlayPanel } from './SketchpadOverlayPanel';
 import * as api from '../api';
+import * as localViewState from '../local-view-state';
 import { fetchSourceInfo, fetchZones, takeSnapshot, blockAction, addBlock } from '../../ui/api/client';
 import { parseDefaultProps } from '../utils';
 import { ToastViewport } from '../../ui/components/ToastViewport';
@@ -287,16 +288,19 @@ export function SketchpadApp() {
   const initialTransformAppliedRef = useRef(false);
 
   // Load registry on mount — auto-create a default sketchpad if none exist.
-  // Restores last-active sketchpad and its persisted pan/zoom.
+  // Restores the last-active sketchpad and its pan/zoom from localStorage; with
+  // nothing saved (fresh browser, cleared storage) it opens the first sketchpad
+  // and the auto-center effect below frames it.
   useEffect(() => {
     api.fetchRegistry().then(async (reg) => {
       if (reg.sketchpads?.length > 0) {
         setSketchpads(reg.sketchpads);
-        const initial =
-          reg.sketchpads.find((s) => s.id === reg.lastActiveSketchpadId) ?? reg.sketchpads[0];
+        const lastActiveId = localViewState.getLastActiveSketchpadId();
+        const initial = reg.sketchpads.find((s) => s.id === lastActiveId) ?? reg.sketchpads[0];
         setActiveSketchpadId(initial.id);
-        if (initial.viewState) {
-          setTransform(initial.viewState);
+        const savedTransform = localViewState.getViewState(initial.id);
+        if (savedTransform) {
+          setTransform(savedTransform);
           initialTransformAppliedRef.current = true;
         }
         loadAllFrameModules(initial.id, initial.frames);
@@ -319,12 +323,14 @@ export function SketchpadApp() {
     if (!activeSketchpadId) return;
     if (lastPersistedActiveRef.current === activeSketchpadId) return;
     lastPersistedActiveRef.current = activeSketchpadId;
-    api.updateSketchpadView(activeSketchpadId, { makeActive: true }).catch(() => {});
+    localViewState.setLastActiveSketchpadId(activeSketchpadId);
   }, [activeSketchpadId]);
 
-  // Debounced + unload-safe persistence of pan/zoom for the active sketchpad.
-  // Skips the very first transform value after switching sketchpads (set programmatically
-  // from saved viewState or from auto-centering) to avoid a redundant write back.
+  // Debounced persistence of pan/zoom for the active sketchpad. localStorage is
+  // synchronous, so this only debounces to keep a pan drag from writing on every
+  // animation frame. Skips the very first transform value after switching
+  // sketchpads (set programmatically from saved state or from auto-centering) to
+  // avoid a redundant write back.
   const lastSavedTransformRef = useRef<{ id: string; transform: CanvasTransform } | null>(null);
   useEffect(() => {
     if (!activeSketchpadId) return;
@@ -337,20 +343,18 @@ export function SketchpadApp() {
     if (last.zoom === transform.zoom && last.panX === transform.panX && last.panY === transform.panY) return;
     const handle = setTimeout(() => {
       lastSavedTransformRef.current = { id: activeSketchpadId, transform };
-      api.updateSketchpadView(activeSketchpadId, { viewState: transform }).catch(() => {});
-    }, 3000);
+      localViewState.saveViewState(activeSketchpadId, transform);
+    }, 300);
     return () => clearTimeout(handle);
   }, [activeSketchpadId, transform]);
 
-  // Save view state on tab close / refresh via sendBeacon.
+  // Flush the camera on tab close / refresh, so a move inside the debounce
+  // window still survives.
   useEffect(() => {
     const flush = () => {
       if (!activeSketchpadId) return;
-      api.updateSketchpadView(
-        activeSketchpadId,
-        { viewState: transform, makeActive: true },
-        { keepalive: true },
-      );
+      localViewState.saveViewState(activeSketchpadId, transform);
+      localViewState.setLastActiveSketchpadId(activeSketchpadId);
     };
     window.addEventListener('pagehide', flush);
     window.addEventListener('beforeunload', flush);
@@ -537,6 +541,7 @@ export function SketchpadApp() {
     async (id: string) => {
       await runLockedMutation(async () => {
         await api.deleteSketchpad(id);
+        localViewState.forgetSketchpad(id);
         const remaining = sketchpads.filter((s) => s.id !== id);
         if (remaining.length === 0) {
           // Auto-create a default sketchpad so the canvas is never empty.
@@ -551,7 +556,7 @@ export function SketchpadApp() {
             setActiveSketchpadId(next.id);
             setSelectedFrameIds([]);
             const rect = containerRef.current?.getBoundingClientRect();
-            const baseTransform = next.viewState ?? INITIAL_TRANSFORM;
+            const baseTransform = localViewState.getViewState(next.id) ?? INITIAL_TRANSFORM;
             const safeTransform =
               rect && rect.width > 0 && rect.height > 0
                 ? ensureFramesVisible(next.frames, baseTransform, rect.width, rect.height)
@@ -1092,13 +1097,13 @@ export function SketchpadApp() {
     // the viewport to it — otherwise the canvas stays panned to where the deleted
     // sketchpad was and shows an empty page.
     if (activeSketchpadId && !reg.sketchpads.some((s) => s.id === activeSketchpadId)) {
-      const next =
-        reg.sketchpads.find((s) => s.id === reg.lastActiveSketchpadId) ?? reg.sketchpads[0];
+      const lastActiveId = localViewState.getLastActiveSketchpadId();
+      const next = reg.sketchpads.find((s) => s.id === lastActiveId) ?? reg.sketchpads[0];
       setActiveSketchpadId(next?.id ?? '');
       setSelectedFrameIds([]);
       if (next) {
         const rect = containerRef.current?.getBoundingClientRect();
-        const baseTransform = next.viewState ?? INITIAL_TRANSFORM;
+        const baseTransform = localViewState.getViewState(next.id) ?? INITIAL_TRANSFORM;
         const safeTransform =
           rect && rect.width > 0 && rect.height > 0
             ? ensureFramesVisible(next.frames, baseTransform, rect.width, rect.height)
@@ -2017,10 +2022,7 @@ export function SketchpadApp() {
           }
           // Persist current transform to the outgoing sketchpad before switching.
           if (activeSketchpadId) {
-            api.updateSketchpadView(activeSketchpadId, { viewState: transform }).catch(() => {});
-            setSketchpads((prev) =>
-              prev.map((s) => (s.id === activeSketchpadId ? { ...s, viewState: transform } : s)),
-            );
+            localViewState.saveViewState(activeSketchpadId, transform);
           }
           setActiveSketchpadId(id);
           setShowSketchpadPanel(false);
@@ -2028,11 +2030,12 @@ export function SketchpadApp() {
           const sp = sketchpads.find((s) => s.id === id);
           if (sp) {
             const rect = containerRef.current?.getBoundingClientRect();
-            if (sp.viewState) {
+            const savedTransform = localViewState.getViewState(sp.id);
+            if (savedTransform) {
               const safeTransform =
                 rect && rect.width > 0 && rect.height > 0
-                  ? ensureFramesVisible(sp.frames, sp.viewState, rect.width, rect.height)
-                  : sp.viewState;
+                  ? ensureFramesVisible(sp.frames, savedTransform, rect.width, rect.height)
+                  : savedTransform;
               setTransform(safeTransform);
               initialTransformAppliedRef.current = true;
             } else {
@@ -2041,7 +2044,7 @@ export function SketchpadApp() {
             }
             loadAllFrameModules(id, sp.frames);
           }
-          api.updateSketchpadView(id, { makeActive: true }).catch(() => {});
+          localViewState.setLastActiveSketchpadId(id);
         }}
         onCreate={handleCreateSketchpad}
         onDelete={handleDeleteSketchpad}

--- a/protovibe-project-template/plugins/protovibe/src/sketchpads/components/SketchpadApp.tsx
+++ b/protovibe-project-template/plugins/protovibe/src/sketchpads/components/SketchpadApp.tsx
@@ -326,11 +326,14 @@ export function SketchpadApp() {
     localViewState.setLastActiveSketchpadId(activeSketchpadId);
   }, [activeSketchpadId]);
 
-  // Debounced persistence of pan/zoom for the active sketchpad. localStorage is
-  // synchronous, so this only debounces to keep a pan drag from writing on every
-  // animation frame. Skips the very first transform value after switching
-  // sketchpads (set programmatically from saved state or from auto-centering) to
-  // avoid a redundant write back.
+  // Debounced persistence of pan/zoom for the active sketchpad. The timer is
+  // trailing — every transform change clears the pending one — so a continuous
+  // pan or zoom writes nothing until the camera has been still for a second,
+  // keeping synchronous localStorage off the main thread during a gesture.
+  // Skips the very first transform value after switching sketchpads (set
+  // programmatically from saved state or from auto-centering) to avoid a
+  // redundant write back. The unload flush below covers a move that never
+  // reaches the timer.
   const lastSavedTransformRef = useRef<{ id: string; transform: CanvasTransform } | null>(null);
   useEffect(() => {
     if (!activeSketchpadId) return;
@@ -344,7 +347,7 @@ export function SketchpadApp() {
     const handle = setTimeout(() => {
       lastSavedTransformRef.current = { id: activeSketchpadId, transform };
       localViewState.saveViewState(activeSketchpadId, transform);
-    }, 300);
+    }, 1000);
     return () => clearTimeout(handle);
   }, [activeSketchpadId, transform]);
 

--- a/protovibe-project-template/plugins/protovibe/src/sketchpads/local-view-state.ts
+++ b/protovibe-project-template/plugins/protovibe/src/sketchpads/local-view-state.ts
@@ -1,0 +1,103 @@
+// plugins/protovibe/src/sketchpads/local-view-state.ts
+// Where the camera was left: the last-active sketchpad and each sketchpad's
+// pan/zoom.
+//
+// This is per-user, per-machine state — it says nothing about the design and
+// everything about who was looking at it. It used to live in
+// `src/sketchpads/_registry.json`, which is committed, so every pan and zoom
+// dirtied a tracked file and two collaborators conflicted on it just by opening
+// a sketchpad. It lives in localStorage instead: never committed, nothing for
+// Git to merge, and no backend round-trip.
+//
+// localStorage is keyed by origin and each project runs on its own dev-server
+// port, so this is naturally scoped per project. A recycled port can hand a new
+// project a stale camera, which is why entries are keyed by sketchpad id and
+// why callers still run the restored transform through `ensureFramesVisible`.
+//
+// Every read is defensive: absent, unparsable, or malformed state is treated as
+// "no saved state" and the caller falls back to auto-centering on the frames.
+
+import type { CanvasTransform } from './types';
+
+const STORAGE_KEY = 'pv-sketchpad-view-state';
+
+interface LocalViewState {
+  lastActiveSketchpadId?: string;
+  viewStates: Record<string, CanvasTransform>;
+}
+
+const EMPTY: LocalViewState = { viewStates: {} };
+
+function isTransform(value: unknown): value is CanvasTransform {
+  const t = value as CanvasTransform | undefined;
+  return (
+    !!t &&
+    typeof t === 'object' &&
+    typeof t.zoom === 'number' && isFinite(t.zoom) && t.zoom > 0 &&
+    typeof t.panX === 'number' && isFinite(t.panX) &&
+    typeof t.panY === 'number' && isFinite(t.panY)
+  );
+}
+
+function read(): LocalViewState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return EMPTY;
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return EMPTY;
+
+    const viewStates: Record<string, CanvasTransform> = {};
+    for (const [id, transform] of Object.entries(parsed.viewStates ?? {})) {
+      if (isTransform(transform)) viewStates[id] = transform;
+    }
+    const lastActiveSketchpadId =
+      typeof parsed.lastActiveSketchpadId === 'string' ? parsed.lastActiveSketchpadId : undefined;
+
+    return { lastActiveSketchpadId, viewStates };
+  } catch {
+    return EMPTY;
+  }
+}
+
+function write(state: LocalViewState): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch { /* storage unavailable or full — persistence is best-effort */ }
+}
+
+/** The sketchpad open when the user last left, or undefined on a fresh browser. */
+export function getLastActiveSketchpadId(): string | undefined {
+  return read().lastActiveSketchpadId;
+}
+
+export function setLastActiveSketchpadId(sketchpadId: string): void {
+  const state = read();
+  if (state.lastActiveSketchpadId === sketchpadId) return;
+  write({ ...state, lastActiveSketchpadId: sketchpadId });
+}
+
+/** Saved pan/zoom for one sketchpad, or undefined when there is none to restore. */
+export function getViewState(sketchpadId: string): CanvasTransform | undefined {
+  return read().viewStates[sketchpadId];
+}
+
+export function saveViewState(sketchpadId: string, transform: CanvasTransform): void {
+  if (!sketchpadId || !isTransform(transform)) return;
+  const state = read();
+  write({ ...state, viewStates: { ...state.viewStates, [sketchpadId]: transform } });
+}
+
+/** Drop a deleted sketchpad's camera so a recycled id can't inherit it. */
+export function forgetSketchpad(sketchpadId: string): void {
+  const state = read();
+  const hasViewState = sketchpadId in state.viewStates;
+  const wasActive = state.lastActiveSketchpadId === sketchpadId;
+  if (!hasViewState && !wasActive) return;
+
+  const viewStates = { ...state.viewStates };
+  delete viewStates[sketchpadId];
+  write({
+    lastActiveSketchpadId: wasActive ? undefined : state.lastActiveSketchpadId,
+    viewStates,
+  });
+}

--- a/protovibe-project-template/plugins/protovibe/src/sketchpads/types.ts
+++ b/protovibe-project-template/plugins/protovibe/src/sketchpads/types.ts
@@ -12,12 +12,12 @@ export interface Sketchpad {
   name: string;
   createdAt: string;
   frames: SketchpadFrame[];
-  viewState?: CanvasTransform;
 }
 
+// Shared design data only. The camera (pan/zoom, last-active sketchpad) is
+// per-user and lives in localStorage — see ./local-view-state.ts.
 export interface Registry {
   sketchpads: Sketchpad[];
-  lastActiveSketchpadId?: string;
 }
 
 export interface CanvasTransform {

--- a/protovibe-project-template/src/sketchpads/_registry.json
+++ b/protovibe-project-template/src/sketchpads/_registry.json
@@ -21,13 +21,7 @@
           "canvasX": 3647,
           "canvasY": -2104
         }
-      ],
-      "viewState": {
-        "zoom": 0.7350168834174952,
-        "panX": -2216.162275784197,
-        "panY": 1584.6771356741683
-      }
+      ]
     }
-  ],
-  "lastActiveSketchpadId": "sketchpad-1"
+  ]
 }


### PR DESCRIPTION
The last-active sketchpad and each sketchpad's pan/zoom lived in
src/sketchpads/_registry.json, which is committed. Panning or zooming
rewrote a tracked file on a 3s debounce plus a sendBeacon flush on tab
close, so `git add -A` in the sync flow picked it up constantly and two
people conflicted on the file just by opening a sketchpad.

None of that is design data — it is per-user, per-machine camera state,
so it now lives in localStorage under `pv-sketchpad-view-state`:

- New sketchpads/local-view-state.ts owns the storage, validating every
  read so absent, unparsable, or malformed state reads as "nothing
  saved".
- SketchpadApp reads and writes it directly. With no saved camera it
  falls back to opening the first sketchpad and auto-centering on its
  frames, as before. Restored transforms still pass through
  ensureFramesVisible, which now also covers stale localStorage.
- Deleting a sketchpad drops its stored camera so a recycled id cannot
  inherit it.
- The /__sketchpad-update-view endpoint and its api client are gone; the
  registry is design data only. readRegistry/writeRegistry strip the
  legacy viewState and lastActiveSketchpadId fields, so the first write
  in an existing project cleans the committed file.

Debounce drops from 3s to 300ms now that the write is a synchronous
localStorage set rather than an HTTP round-trip.

Verified against the running shell with Playwright: a pan survives a
reload, two sketchpads keep independent cameras across switches, a fresh
browser auto-centers, _registry.json stays byte-identical throughout,
and /__sketchpad-update-view is never requested.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016C5Mbvq88DhjtJwetkKFSJ