### PR TITLE
Always offer step-by-step GitHub help when Git sync fails

### DIFF
--- a/protovibe-project-template/plugins/protovibe/src/backend/git-server.ts
+++ b/protovibe-project-template/plugins/protovibe/src/backend/git-server.ts
@@ -219,6 +219,13 @@ export interface GitOpState {
   repoUrl?: string;
 }
 
+// Plain-language failure messages, one per step, so the headline the user reads
+// matches what actually went wrong. The UI adds the "here's what to do about it"
+// half (see ui/components/GitMenu.tsx), so these only have to name the step.
+const FETCH_FAILED_MESSAGE = 'Couldn’t reach your project on GitHub.';
+const MERGE_FAILED_MESSAGE = 'Couldn’t combine your team’s changes with yours.';
+const PUSH_FAILED_MESSAGE = 'Couldn’t send your work to GitHub.';
+
 let gitOpState: GitOpState = { status: 'idle', message: '' };
 let gitOpTimestamp = 0;
 
@@ -275,7 +282,7 @@ async function stageAndCommit(message: string): Promise<boolean> {
 }
 
 /**
- * Fetch remote work and rebase our local commits on top of it, with last-write-wins
+ * Rebase our local commits onto the already-fetched upstream, with last-write-wins
  * on true same-line conflicts. Returns whether a conflict was auto-resolved.
  *
  * Two-phase so we can detect conflicts deterministically (a `-X theirs` rebase
@@ -285,10 +292,13 @@ async function stageAndCommit(message: string): Promise<boolean> {
  *      "theirs" = the commits being replayed = our local edits), so the syncer wins.
  *      Success here means we overrode a conflicting edit → true.
  * A rebase that even `-X theirs` can't settle (e.g. rename/delete) aborts and rethrows.
+ *
+ * The fetch is deliberately NOT part of this: a fetch that fails because the
+ * machine isn't signed in to GitHub is the single most common sync failure our
+ * users hit, and reporting it as "couldn't merge" sends them looking for a
+ * conflict that doesn't exist. Callers fetch first and say so themselves.
  */
-async function fetchAndRebase(): Promise<boolean> {
-  await gitNet(['fetch'], 90_000);
-
+async function rebaseOntoUpstream(): Promise<boolean> {
   // Fast path: clean rebase (no overlapping edits, or nothing to integrate).
   try {
     await git(['rebase', '@{u}'], 60_000);
@@ -313,21 +323,28 @@ async function runGitSync(): Promise<void> {
     await stageAndCommit(autoCommitMessage());
 
     setGitOpState({ status: 'pulling', message: 'Getting the latest…', op: 'sync' });
+    try {
+      await gitNet(['fetch'], 90_000);
+    } catch (err) {
+      setGitOpState({ status: 'error', message: FETCH_FAILED_MESSAGE, op: 'sync', error: String(err) });
+      return;
+    }
+
     let resolvedConflict = false;
     try {
-      resolvedConflict = await fetchAndRebase();
+      resolvedConflict = await rebaseOntoUpstream();
     } catch (err) {
-      setGitOpState({
-        status: 'error',
-        message: 'Could not merge remote changes automatically. Ask your coding agent for help.',
-        op: 'sync',
-        error: String(err),
-      });
+      setGitOpState({ status: 'error', message: MERGE_FAILED_MESSAGE, op: 'sync', error: String(err) });
       return;
     }
 
     setGitOpState({ status: 'pushing', message: 'Publishing…', op: 'sync' });
-    await gitNet(['push'], 90_000);
+    try {
+      await gitNet(['push'], 90_000);
+    } catch (err) {
+      setGitOpState({ status: 'error', message: PUSH_FAILED_MESSAGE, op: 'sync', error: String(err) });
+      return;
+    }
 
     setGitOpState({
       status: 'success',
@@ -336,7 +353,7 @@ async function runGitSync(): Promise<void> {
       resolvedConflict,
     });
   } catch (err) {
-    setGitOpState({ status: 'error', message: 'Sync failed.', op: 'sync', error: String(err) });
+    setGitOpState({ status: 'error', message: 'Syncing didn’t work.', op: 'sync', error: String(err) });
   }
 }
 
@@ -441,11 +458,17 @@ async function runManualOp(op: GitOp, message?: string): Promise<void> {
     }
     if (op === 'pull') {
       setGitOpState({ status: 'pulling', message: 'Getting the latest…', op });
+      try {
+        await gitNet(['fetch'], 90_000);
+      } catch (err) {
+        setGitOpState({ status: 'error', message: FETCH_FAILED_MESSAGE, op, error: String(err) });
+        return;
+      }
       let resolvedConflict = false;
       try {
-        resolvedConflict = await fetchAndRebase();
+        resolvedConflict = await rebaseOntoUpstream();
       } catch (err) {
-        setGitOpState({ status: 'error', message: 'Could not merge remote changes automatically.', op, error: String(err) });
+        setGitOpState({ status: 'error', message: MERGE_FAILED_MESSAGE, op, error: String(err) });
         return;
       }
       setGitOpState({ status: 'success', message: resolvedConflict ? 'Pulled — resolved a conflicting edit' : 'Pulled', op, resolvedConflict });
@@ -453,7 +476,12 @@ async function runManualOp(op: GitOp, message?: string): Promise<void> {
     }
     if (op === 'push') {
       setGitOpState({ status: 'pushing', message: 'Publishing…', op });
-      await gitNet(['push'], 90_000);
+      try {
+        await gitNet(['push'], 90_000);
+      } catch (err) {
+        setGitOpState({ status: 'error', message: PUSH_FAILED_MESSAGE, op, error: String(err) });
+        return;
+      }
       setGitOpState({ status: 'success', message: 'Pushed', op });
       return;
     }
@@ -464,7 +492,7 @@ async function runManualOp(op: GitOp, message?: string): Promise<void> {
     // op === 'sync'
     await runGitSync();
   } catch (err) {
-    setGitOpState({ status: 'error', message: `${op} failed.`, op, error: String(err) });
+    setGitOpState({ status: 'error', message: 'That didn’t work.', op, error: String(err) });
   }
 }
 

--- a/protovibe-project-template/plugins/protovibe/src/ui/components/GitMenu.tsx
+++ b/protovibe-project-template/plugins/protovibe/src/ui/components/GitMenu.tsx
@@ -6,8 +6,14 @@
 // When Git isn't ready we explain the situation in plain language. Projects
 // without a repo/remote get an intro to GitHub (what it is, why a designer would
 // want it) and a one-click flow: connect via the Protovibe manager app, then
-// init + private repo + push. The old paste-to-your-coding-agent prompts remain
-// as a collapsed escape hatch.
+// init + private repo + push.
+//
+// Every failure ends in the same place: a paste-to-your-coding-agent prompt
+// (see utils/gitAgentPrompts.ts). Our own one-click remedies only cover the
+// Protovibe-managed token — a machine that GitHub refuses, or a project whose
+// online copy has gone missing, needs a terminal and `gh auth login`, which our
+// users can't do unaided. So the prompt is present after *any* failed op:
+// expanded when we have nothing better to offer, a quiet link when we do.
 
 import React, { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
@@ -15,6 +21,17 @@ import { GitBranch, RotateCw, ChevronDown, Download, Upload, GitCommit, RefreshC
 import { useFloatingDropdownPosition } from '../hooks/useFloatingDropdownPosition';
 import { theme, primarySolidHover } from '../theme';
 import { openInBrowser } from '../utils/openExternal';
+import { PV_GIT_MENU_OPEN_EVENT } from '../events/gitMenu';
+import {
+  detectOs,
+  classifyGitFailure,
+  isGithubAccessFailure,
+  syncFailurePrompt,
+  installGitPrompt,
+  setupRepoPrompt,
+  connectRemotePrompt,
+  type GitFailureKind,
+} from '../utils/gitAgentPrompts';
 import type { UseGitSync } from '../hooks/useGitSync';
 
 const SPIN_KEYFRAMES = '@keyframes pv-git-spin { to { transform: rotate(360deg); } }';
@@ -26,45 +43,24 @@ const GithubMark: React.FC<{ size?: number }> = ({ size = 14 }) => (
   </svg>
 );
 
-function osName(): string {
-  const ua = navigator.userAgent;
-  if (/Mac/i.test(ua)) return 'macOS';
-  if (/Win/i.test(ua)) return 'Windows';
-  return 'Linux';
+// Plain-language headline for a failed sync, matched to why it failed. Both the
+// "GitHub said no" and the "we can't find the project online" cases come down to
+// the same thing for a designer — this computer was never signed in to GitHub —
+// so both point at the same coding-agent prompt.
+function failureHeadline(kind: GitFailureKind): string {
+  if (kind === 'auth') {
+    return 'GitHub wouldn’t accept your work from this computer — it isn’t signed in to GitHub yet.';
+  }
+  if (kind === 'remote-missing') {
+    return 'Protovibe couldn’t find your project’s online copy on GitHub — usually because this computer isn’t signed in to GitHub yet.';
+  }
+  return 'This isn’t something Protovibe can sort out on its own.';
 }
 
-// --- Prompts the user can paste into their coding agent (Claude Code, etc.) ---
-
-const projectLine = (root: string) => (root ? `\n\nThe project folder is at: ${root}` : '');
-
-const installPrompt = (root: string) =>
-  `I'm using Protovibe to design an app on ${osName()}, and Git isn't installed on this computer. ` +
-  `Please install Git, verify it works by running \`git --version\`, and let me know when it's ready so I can sync my work with my team.` +
-  projectLine(root);
-
-const setupRepoPrompt = (root: string) =>
-  `I'm using Protovibe and want to sync my work with my team, but this project isn't set up with Git version control yet. ` +
-  `Please set it up: initialize a Git repository here, connect it to a remote (create a new GitHub repository if I don't have one), ` +
-  `make an initial commit, set the upstream for my branch, and push. Then tell me I can sync from Protovibe.` +
-  projectLine(root);
-
-const connectRemotePrompt = (root: string) =>
-  `I'm using Protovibe. This project has Git, but my current branch isn't connected to a shared remote yet, so I can't sync with my team. ` +
-  `Please connect it to a remote (create or use a GitHub repository), set the upstream tracking branch for my current branch, and push. ` +
-  `Then confirm I can sync from Protovibe.` +
-  projectLine(root);
-
-const authPrompt = (root: string, error?: string) =>
-  `I'm using Protovibe and tried to sync my work with Git, but it failed. ` +
-  `I think Git access isn't set up on this computer. Please fix my Git authentication for this project's remote ` +
-  `(set up an SSH key or a credential helper / sign me in), verify it works by running \`git push\`, and confirm I can sync from Protovibe.` +
-  projectLine(root) +
-  (error ? `\n\nThe exact error was:\n${error.trim()}` : '');
-
-// git failures that mean "access/credentials aren't set up" rather than a real problem.
-function isAuthOrAccessError(text: string): boolean {
-  return /permission denied|authentication failed|could not read (username|password|from remote)|terminal prompts disabled|invalid username or password|support for password authentication|publickey|access denied|access rights|repository not found|unable to access|host key verification failed|forbidden|please tell me who you are/i.test(text);
-}
+// The one line every failed sync ends on, whatever went wrong: someone can fix
+// this for you, and here is the exact thing to send them.
+const AGENT_HELP_LINE =
+  'Your coding agent can fix this for you. Copy the message below, paste it to your coding agent, and it will walk you through it one small step at a time.';
 
 // Plain-language description of the working state, aimed at non-technical users.
 function plainStatus(s: { changedCount: number; ahead: number; behind: number }): string {
@@ -121,10 +117,18 @@ export const GitMenu: React.FC<{ git: UseGitSync }> = ({ git }) => {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
 
+  const os = detectOs();
   const gitMissing = !!status && !status.gitInstalled;
   const needsBackupPanel = !!status?.gitInstalled && (!status.isRepo || !status.hasUpstream);
-  const authIssue = op.status === 'error' && isAuthOrAccessError(`${op.error ?? ''} ${op.message ?? ''}`);
+
+  // Any failed sync/pull/push earns an explanation and a way out — not just the
+  // ones we can classify. `failureKind` only decides how confident the wording is.
+  const opFailed = op.status === 'error';
+  const failureText = `${op.error ?? ''} ${op.message ?? ''}`;
+  const failureKind = opFailed ? classifyGitFailure(failureText) : 'other';
+  const authIssue = opFailed && isGithubAccessFailure(failureText);
   const githubAuthIssue = authIssue && status?.remoteKind === 'github-https';
+  const helpPrompt = syncFailurePrompt(failureKind, os, status?.root ?? '', op.error);
 
   const { style: menuStyle } = useFloatingDropdownPosition({
     isOpen: open,
@@ -178,6 +182,14 @@ export const GitMenu: React.FC<{ git: UseGitSync }> = ({ git }) => {
     return () => window.removeEventListener('mousedown', onDown);
   }, [open]);
 
+  // A git op that failed anywhere (the bottom-right banner, say) asks for the
+  // menu so the user always lands on the explanation instead of a lone toast.
+  useEffect(() => {
+    const onOpenRequest = () => setOpen(true);
+    window.addEventListener(PV_GIT_MENU_OPEN_EVENT, onOpenRequest);
+    return () => window.removeEventListener(PV_GIT_MENU_OPEN_EVENT, onOpenRequest);
+  }, []);
+
   // Cmd+S (macOS) / Ctrl+S (Windows/Linux) opens the Sync with Git popover
   // instead of the browser's Save dialog.
   useEffect(() => {
@@ -200,6 +212,15 @@ export const GitMenu: React.FC<{ git: UseGitSync }> = ({ git }) => {
   const backupNeedsInstall = op.status === 'error' && op.op === 'backup' && !!op.needsInstall;
   const syncNeedsInstall = githubAuthIssue && !!github?.connected && (repoAccess?.state === 'not-covered' || repoAccess?.state === 'no-push');
   const installUrl = op.installUrl || repoAccess?.installUrl || github?.installUrl || '';
+  // Is there a first-line fix of our own on screen? If so the coding-agent prompt
+  // sits collapsed underneath it rather than shouting over it — but it is always
+  // there, because our own remedies don't cover a machine that was never signed in.
+  const hasQuickFix = (githubAuthIssue && !!github && !github.connected) || syncNeedsInstall;
+
+  const backupFailed = opFailed && op.op === 'backup';
+  const backupHelpPrompt = !status.isRepo
+    ? setupRepoPrompt(os, status.root, backupFailed ? op.error : undefined)
+    : connectRemotePrompt(os, status.root, backupFailed ? op.error : undefined);
 
   return (
     <>
@@ -245,7 +266,12 @@ export const GitMenu: React.FC<{ git: UseGitSync }> = ({ git }) => {
             padding: 0,
             zIndex: 9999,
             width: 288,
-            overflow: 'hidden',
+            // The hook caps our height to the space above the bottom bar. An
+            // error panel plus the agent prompt can outgrow that on a short
+            // screen, and clipping would hide the Sync button below it — so
+            // scroll instead of cutting the panel off.
+            overflowX: 'hidden',
+            overflowY: 'auto',
           }}
         >
           <style>{SPIN_KEYFRAMES}</style>
@@ -266,7 +292,7 @@ export const GitMenu: React.FC<{ git: UseGitSync }> = ({ git }) => {
                 cancelConnect={cancelConnect}
                 checkGithub={checkGithub}
               />
-              <TroubleFallback prompt={installPrompt(status.root)} />
+              <AgentHelp prompt={installGitPrompt(os, status.root)} linkLabel="Taking too long? Get help" />
             </div>
           ) : needsBackupPanel ? (
             /* --- no repo / no remote: intro + one-click connect to GitHub --- */
@@ -300,8 +326,9 @@ export const GitMenu: React.FC<{ git: UseGitSync }> = ({ git }) => {
                       {backupBusy
                         ? <RotateCw size={14} style={{ animation: 'pv-git-spin 1s linear infinite' }} />
                         : <GithubMark size={14} />}
-                      {backupBusy ? (op.message || 'Setting up…') : op.status === 'error' && op.op === 'backup' ? 'Try again' : 'Add project to GitHub'}
+                      {backupBusy ? (op.message || 'Setting up…') : backupFailed ? 'Try again' : 'Add project to GitHub'}
                     </button>
+                    {backupFailed && <AgentHelp prompt={backupHelpPrompt} startExpanded />}
                   </>
                 )
               ) : connecting ? (
@@ -367,7 +394,8 @@ export const GitMenu: React.FC<{ git: UseGitSync }> = ({ git }) => {
                 </button>
                 {otherOptionsOpen && (
                   <div style={{ padding: '4px 12px 8px', display: 'flex', flexDirection: 'column', gap: 8 }}>
-                    <AgentPrompt prompt={!status.isRepo ? setupRepoPrompt(status.root) : connectRemotePrompt(status.root)} />
+                    <div style={{ color: theme.text_secondary, fontSize: 12, lineHeight: 1.45 }}>{AGENT_HELP_LINE}</div>
+                    <AgentPrompt prompt={backupHelpPrompt} />
                     <button
                       onClick={() => void refresh(true)}
                       style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6, padding: '4px 0', border: 'none', background: 'transparent', color: theme.text_tertiary, fontSize: 12, cursor: 'pointer' }}
@@ -393,62 +421,56 @@ export const GitMenu: React.FC<{ git: UseGitSync }> = ({ git }) => {
                 </div>
               </div>
 
-              {/* auth / access problem */}
-              {authIssue && (
-                <div style={{ padding: '12px 12px 4px', display: 'flex', flexDirection: 'column', gap: 8, borderBottom: `1px solid ${theme.border_default}` }}>
-                  {githubAuthIssue ? (
-                    !github ? (
-                      <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: theme.text_secondary, fontSize: 12 }}>
-                        <RotateCw size={13} style={{ animation: 'pv-git-spin 1s linear infinite' }} /> Checking your GitHub connection…
+              {/* something went wrong — explain it, then always offer the agent */}
+              {opFailed && (
+                <div style={{ padding: '12px 12px 4px', display: 'flex', flexDirection: 'column', gap: 10, borderBottom: `1px solid ${theme.border_default}` }}>
+                  <div style={{ color: theme.text_secondary, fontSize: 12, lineHeight: 1.45 }}>
+                    {failureHeadline(failureKind)}
+                  </div>
+
+                  {/* One-click remedies we can offer ourselves, when they apply. */}
+                  {githubAuthIssue && !github && (
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: theme.text_secondary, fontSize: 12 }}>
+                      <RotateCw size={13} style={{ animation: 'pv-git-spin 1s linear infinite' }} /> Checking your GitHub connection…
+                    </div>
+                  )}
+                  {githubAuthIssue && !!github && !github.connected && (
+                    connecting ? (
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: theme.text_secondary, fontSize: 12, lineHeight: 1.5 }}>
+                        <RotateCw size={13} style={{ flexShrink: 0, animation: 'pv-git-spin 1s linear infinite' }} />
+                        Waiting for you to finish connecting in the Protovibe app…
                       </div>
-                    ) : !github.connected ? (
-                      connecting ? (
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: theme.text_secondary, fontSize: 12, lineHeight: 1.5 }}>
-                          <RotateCw size={13} style={{ flexShrink: 0, animation: 'pv-git-spin 1s linear infinite' }} />
-                          Waiting for you to finish connecting in the Protovibe app…
-                        </div>
-                      ) : github.managerReachable === undefined ? (
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: theme.text_secondary, fontSize: 12 }}>
-                          <RotateCw size={13} style={{ animation: 'pv-git-spin 1s linear infinite' }} /> Looking for the Protovibe app…
-                        </div>
-                      ) : github.managerReachable ? (
-                        <>
-                          <div style={{ color: theme.text_secondary, fontSize: 12, lineHeight: 1.45 }}>
-                            Syncing needs your GitHub account. Connect it and try again.
-                          </div>
-                          <button onClick={startConnect} {...primarySolidHover(true)} style={primaryButtonStyle(true)}>
-                            <GithubMark size={14} /> Connect GitHub
-                          </button>
-                        </>
-                      ) : (
-                        <div style={{ color: theme.text_secondary, fontSize: 12, lineHeight: 1.45 }}>
-                          Syncing needs your GitHub account. Open the Protovibe app to connect it, then try sync again.
-                        </div>
-                      )
-                    ) : syncNeedsInstall ? (
-                      <InstallAccessPanel
-                        installUrl={installUrl}
-                        body="GitHub needs your permission before Protovibe can use this repository. Open GitHub, give Protovibe access to it, then sync again."
-                        retryLabel="I’ve done it — sync again"
-                        onRetry={() => void runOp('sync')}
-                        disabled={busy}
-                      />
-                    ) : (
+                    ) : github.managerReachable === undefined ? (
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: theme.text_secondary, fontSize: 12 }}>
+                        <RotateCw size={13} style={{ animation: 'pv-git-spin 1s linear infinite' }} /> Looking for the Protovibe app…
+                      </div>
+                    ) : github.managerReachable ? (
                       <>
                         <div style={{ color: theme.text_secondary, fontSize: 12, lineHeight: 1.45 }}>
-                          Syncing failed even though your GitHub account is connected. Try again — if it keeps failing, your coding agent can help.
+                          The quickest fix is to connect your GitHub account here, then try again.
                         </div>
-                        <AgentPrompt prompt={authPrompt(status.root, op.error)} />
+                        <button onClick={startConnect} {...primarySolidHover(true)} style={primaryButtonStyle(true)}>
+                          <GithubMark size={14} /> Connect GitHub
+                        </button>
                       </>
-                    )
-                  ) : (
-                    <>
+                    ) : (
                       <div style={{ color: theme.text_secondary, fontSize: 12, lineHeight: 1.45 }}>
-                        Syncing failed because Git access isn’t set up on this computer. Your coding agent can fix this for you.
+                        The quickest fix is to open the Protovibe app and connect your GitHub account there, then try again.
                       </div>
-                      <AgentPrompt prompt={authPrompt(status.root, op.error)} />
-                    </>
+                    )
                   )}
+                  {syncNeedsInstall && (
+                    <InstallAccessPanel
+                      installUrl={installUrl}
+                      body="GitHub also needs your permission before Protovibe can use this project. Open GitHub, tick this project, then sync again."
+                      retryLabel="I’ve done it — sync again"
+                      onRetry={() => void runOp('sync')}
+                      disabled={busy}
+                    />
+                  )}
+
+                  {/* Always here, whatever went wrong and whatever else we offered. */}
+                  <AgentHelp prompt={helpPrompt} startExpanded={!hasQuickFix} />
                 </div>
               )}
 
@@ -463,7 +485,7 @@ export const GitMenu: React.FC<{ git: UseGitSync }> = ({ git }) => {
                   {busy
                     ? <RotateCw size={14} style={{ animation: 'pv-git-spin 1s linear infinite' }} />
                     : <RefreshCw size={14} />}
-                  {busy ? (op.message || 'Syncing…') : authIssue ? 'Try sync again' : 'Sync changes'}
+                  {busy ? (op.message || 'Syncing…') : opFailed ? 'Try sync again' : 'Sync changes'}
                 </button>
                 <div style={{ color: theme.text_secondary, fontSize: 12, textAlign: 'left' }}>
                   You’re on Git branch: <span style={{ color: theme.text_default, fontWeight: 600 }}>{status.branch || 'unknown'}</span>
@@ -751,10 +773,21 @@ const ConnectBlock: React.FC<{
   );
 };
 
-// Last-resort escape hatch while git provisioning drags on: collapsed by
-// default so designers aren't greeted with an agent prompt.
-const TroubleFallback: React.FC<{ prompt: string }> = ({ prompt }) => {
-  const [expanded, setExpanded] = useState(false);
+// "Ask your coding agent" — the way out of every Git problem we can't fix from
+// here, since the real fix (signing this computer in to GitHub) needs a terminal.
+// Expanded when there's nothing else on offer; a quiet one-line link when we've
+// already put a first-line fix on screen — but never absent after a failure.
+const AgentHelp: React.FC<{ prompt: string; startExpanded?: boolean; linkLabel?: string }> = ({
+  prompt,
+  startExpanded = false,
+  linkLabel = 'Ask your coding agent to fix this',
+}) => {
+  const [expanded, setExpanded] = useState(startExpanded);
+
+  // A quick fix disappearing (the user connected GitHub, say, and it still fails)
+  // should open the prompt rather than leave them staring at a link.
+  useEffect(() => { if (startExpanded) setExpanded(true); }, [startExpanded]);
+
   if (!expanded) {
     return (
       <button
@@ -763,11 +796,17 @@ const TroubleFallback: React.FC<{ prompt: string }> = ({ prompt }) => {
         onMouseEnter={(e) => (e.currentTarget.style.color = theme.text_secondary)}
         onMouseLeave={(e) => (e.currentTarget.style.color = theme.text_tertiary)}
       >
-        Taking too long? Get help
+        {linkLabel}
       </button>
     );
   }
-  return <AgentPrompt prompt={prompt} />;
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <div style={{ color: theme.text_secondary, fontSize: 12, lineHeight: 1.45 }}>{AGENT_HELP_LINE}</div>
+      <AgentPrompt prompt={prompt} />
+    </div>
+  );
 };
 
 // A ready-to-paste prompt for the user's coding agent, with a Copy button.

--- a/protovibe-project-template/plugins/protovibe/src/ui/components/GitMenu.tsx
+++ b/protovibe-project-template/plugins/protovibe/src/ui/components/GitMenu.tsx
@@ -47,7 +47,13 @@ const GithubMark: React.FC<{ size?: number }> = ({ size = 14 }) => (
 // "GitHub said no" and the "we can't find the project online" cases come down to
 // the same thing for a designer — this computer was never signed in to GitHub —
 // so both point at the same coding-agent prompt.
-function failureHeadline(kind: GitFailureKind): string {
+function failureHeadline(kind: GitFailureKind, needsInstall: boolean): string {
+  // Their account is connected and fine — GitHub just hasn't been told this
+  // particular project is one Protovibe may touch. Saying "not signed in" here
+  // contradicts the account row at the bottom of the very same panel.
+  if (needsInstall) {
+    return 'Your GitHub account is connected, but GitHub hasn’t given Protovibe permission for this project yet.';
+  }
   if (kind === 'auth') {
     return 'GitHub wouldn’t accept your work from this computer — it isn’t signed in to GitHub yet.';
   }
@@ -212,10 +218,12 @@ export const GitMenu: React.FC<{ git: UseGitSync }> = ({ git }) => {
   const backupNeedsInstall = op.status === 'error' && op.op === 'backup' && !!op.needsInstall;
   const syncNeedsInstall = githubAuthIssue && !!github?.connected && (repoAccess?.state === 'not-covered' || repoAccess?.state === 'no-push');
   const installUrl = op.installUrl || repoAccess?.installUrl || github?.installUrl || '';
-  // Is there a first-line fix of our own on screen? If so the coding-agent prompt
-  // sits collapsed underneath it rather than shouting over it — but it is always
-  // there, because our own remedies don't cover a machine that was never signed in.
-  const hasQuickFix = (githubAuthIssue && !!github && !github.connected) || syncNeedsInstall;
+  // The coding-agent prompt collapses to a link only when we have a remedy we
+  // *know* fixes the failure — the GitHub install page for a repo the app doesn't
+  // cover. "Connect your GitHub account" doesn't qualify: connecting doesn't help
+  // a machine git itself can't authenticate, which is the usual cause here, so
+  // that case keeps the prompt open underneath the connect button.
+  const hasQuickFix = syncNeedsInstall;
 
   const backupFailed = opFailed && op.op === 'backup';
   const backupHelpPrompt = !status.isRepo
@@ -425,7 +433,7 @@ export const GitMenu: React.FC<{ git: UseGitSync }> = ({ git }) => {
               {opFailed && (
                 <div style={{ padding: '12px 12px 4px', display: 'flex', flexDirection: 'column', gap: 10, borderBottom: `1px solid ${theme.border_default}` }}>
                   <div style={{ color: theme.text_secondary, fontSize: 12, lineHeight: 1.45 }}>
-                    {failureHeadline(failureKind)}
+                    {failureHeadline(failureKind, syncNeedsInstall)}
                   </div>
 
                   {/* One-click remedies we can offer ourselves, when they apply. */}
@@ -462,7 +470,7 @@ export const GitMenu: React.FC<{ git: UseGitSync }> = ({ git }) => {
                   {syncNeedsInstall && (
                     <InstallAccessPanel
                       installUrl={installUrl}
-                      body="GitHub also needs your permission before Protovibe can use this project. Open GitHub, tick this project, then sync again."
+                      body="Open GitHub, tick this project in the list, then come back and sync again."
                       retryLabel="I’ve done it — sync again"
                       onRetry={() => void runOp('sync')}
                       disabled={busy}

--- a/protovibe-project-template/plugins/protovibe/src/ui/components/GitMenu.tsx
+++ b/protovibe-project-template/plugins/protovibe/src/ui/components/GitMenu.tsx
@@ -9,11 +9,13 @@
 // init + private repo + push.
 //
 // Every failure ends in the same place: a paste-to-your-coding-agent prompt
-// (see utils/gitAgentPrompts.ts). Our own one-click remedies only cover the
-// Protovibe-managed token — a machine that GitHub refuses, or a project whose
-// online copy has gone missing, needs a terminal and `gh auth login`, which our
-// users can't do unaided. So the prompt is present after *any* failed op:
-// expanded when we have nothing better to offer, a quiet link when we do.
+// (see utils/gitAgentPrompts.ts), open, after *any* failed op. Our own one-click
+// remedies don't reach the real causes — a machine that GitHub refuses, or a
+// project whose online copy has gone missing, needs a terminal and
+// `gh auth login`, which our users can't do unaided. We deliberately do NOT send
+// them to GitHub's app-installation page from here either: finding the right
+// repository in that list defeats someone who has never used GitHub, and on a
+// company repository they're usually not allowed to grant it anyway.
 
 import React, { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
@@ -50,9 +52,11 @@ const GithubMark: React.FC<{ size?: number }> = ({ size = 14 }) => (
 function failureHeadline(kind: GitFailureKind, needsInstall: boolean): string {
   // Their account is connected and fine — GitHub just hasn't been told this
   // particular project is one Protovibe may touch. Saying "not signed in" here
-  // contradicts the account row at the bottom of the very same panel.
+  // contradicts the account row at the bottom of the very same panel. Granting
+  // it may not even be theirs to do, so don't imply it's a setting they can go
+  // and flip; the prompt below handles both cases.
   if (needsInstall) {
-    return 'Your GitHub account is connected, but GitHub hasn’t given Protovibe permission for this project yet.';
+    return 'Your GitHub account is connected, but GitHub hasn’t given Protovibe permission for this project — and on a company project that may not be yours to change.';
   }
   if (kind === 'auth') {
     return 'GitHub wouldn’t accept your work from this computer — it isn’t signed in to GitHub yet.';
@@ -134,7 +138,6 @@ export const GitMenu: React.FC<{ git: UseGitSync }> = ({ git }) => {
   const failureKind = opFailed ? classifyGitFailure(failureText) : 'other';
   const authIssue = opFailed && isGithubAccessFailure(failureText);
   const githubAuthIssue = authIssue && status?.remoteKind === 'github-https';
-  const helpPrompt = syncFailurePrompt(failureKind, os, status?.root ?? '', op.error);
 
   const { style: menuStyle } = useFloatingDropdownPosition({
     isOpen: open,
@@ -216,14 +219,14 @@ export const GitMenu: React.FC<{ git: UseGitSync }> = ({ git }) => {
 
   const backupBusy = busy && op.op === 'backup';
   const backupNeedsInstall = op.status === 'error' && op.op === 'backup' && !!op.needsInstall;
+  // GitHub knows this account but won't let Protovibe near this repository.
+  // We don't send the user to the install page for it: picking the right repo
+  // out of GitHub's list is beyond someone who has never used GitHub, and on a
+  // company repo they usually aren't allowed to grant it at all. It only shapes
+  // what we tell them and what the agent prompt says.
   const syncNeedsInstall = githubAuthIssue && !!github?.connected && (repoAccess?.state === 'not-covered' || repoAccess?.state === 'no-push');
   const installUrl = op.installUrl || repoAccess?.installUrl || github?.installUrl || '';
-  // The coding-agent prompt collapses to a link only when we have a remedy we
-  // *know* fixes the failure — the GitHub install page for a repo the app doesn't
-  // cover. "Connect your GitHub account" doesn't qualify: connecting doesn't help
-  // a machine git itself can't authenticate, which is the usual cause here, so
-  // that case keeps the prompt open underneath the connect button.
-  const hasQuickFix = syncNeedsInstall;
+  const helpPrompt = syncFailurePrompt(failureKind, os, status.root, op.error, syncNeedsInstall);
 
   const backupFailed = opFailed && op.op === 'backup';
   const backupHelpPrompt = !status.isRepo
@@ -467,18 +470,8 @@ export const GitMenu: React.FC<{ git: UseGitSync }> = ({ git }) => {
                       </div>
                     )
                   )}
-                  {syncNeedsInstall && (
-                    <InstallAccessPanel
-                      installUrl={installUrl}
-                      body="Open GitHub, tick this project in the list, then come back and sync again."
-                      retryLabel="I’ve done it — sync again"
-                      onRetry={() => void runOp('sync')}
-                      disabled={busy}
-                    />
-                  )}
-
-                  {/* Always here, whatever went wrong and whatever else we offered. */}
-                  <AgentHelp prompt={helpPrompt} startExpanded={!hasQuickFix} />
+                  {/* The way out of every failed sync, always open. */}
+                  <AgentHelp prompt={helpPrompt} startExpanded />
                 </div>
               )}
 

--- a/protovibe-project-template/plugins/protovibe/src/ui/events/gitMenu.ts
+++ b/protovibe-project-template/plugins/protovibe/src/ui/events/gitMenu.ts
@@ -1,0 +1,11 @@
+// plugins/protovibe/src/ui/events/gitMenu.ts
+// Lets anything that runs a git operation pop the bottom-bar Git menu open.
+// A sync can be started from the bottom-right "Someone made an update" banner,
+// where a failure would otherwise only be a toast that scrolls away — and the
+// explanation of what to do next lives in the menu. So on failure we open it.
+
+export const PV_GIT_MENU_OPEN_EVENT = 'pv-git-menu-open';
+
+export function openGitMenu(): void {
+  window.dispatchEvent(new CustomEvent(PV_GIT_MENU_OPEN_EVENT));
+}

--- a/protovibe-project-template/plugins/protovibe/src/ui/hooks/useGitSync.ts
+++ b/protovibe-project-template/plugins/protovibe/src/ui/hooks/useGitSync.ts
@@ -17,6 +17,7 @@ import {
   type GithubRepoAccess,
 } from '../api/client';
 import { emitToast } from '../events/toast';
+import { openGitMenu } from '../events/gitMenu';
 import { openLocalWindow } from '../utils/openExternal';
 
 const POLL_INTERVAL_MS = 120_000; // background remote check — every 2 minutes
@@ -207,8 +208,14 @@ export function useGitSync(): UseGitSync {
         if (opName === 'sync' || opName === 'pull') {
           window.dispatchEvent(new CustomEvent('pv-comments-refresh'));
         }
-      } else if (latest.status === 'error' && !latest.needsInstall) {
-        emitToast({ variant: 'error', message: latest.error || latest.message || 'Git operation failed', durationMs: 6000 });
+      } else if (latest.status === 'error') {
+        if (!latest.needsInstall) {
+          emitToast({ variant: 'error', message: latest.message || 'Git operation failed', durationMs: 6000 });
+        }
+        // The menu is where we explain what to do about it. A sync started from
+        // the banner (or a keyboard shortcut) would otherwise leave the user with
+        // a toast and no way forward, so surface the guidance every time.
+        openGitMenu();
       }
 
       await refresh(false);
@@ -219,8 +226,9 @@ export function useGitSync(): UseGitSync {
         setTimeout(() => { if (mounted.current) setOp(IDLE_OP); }, 4000);
       }
     } catch (err) {
-      emitToast({ variant: 'error', message: err instanceof Error ? err.message : String(err), durationMs: 6000 });
-      setOp({ status: 'error', message: 'Failed to start', op: opName, error: String(err) });
+      emitToast({ variant: 'error', message: 'Couldn’t start syncing.', durationMs: 6000 });
+      setOp({ status: 'error', message: 'Couldn’t start syncing.', op: opName, error: String(err) });
+      openGitMenu();
     } finally {
       opRunning.current = false;
     }

--- a/protovibe-project-template/plugins/protovibe/src/ui/utils/gitAgentPrompts.ts
+++ b/protovibe-project-template/plugins/protovibe/src/ui/utils/gitAgentPrompts.ts
@@ -1,0 +1,214 @@
+// plugins/protovibe/src/ui/utils/gitAgentPrompts.ts
+// Ready-to-paste prompts for the user's coding agent when anything Git-related
+// goes wrong in Protovibe.
+//
+// Protovibe's users are designers and copywriters — many have never opened a
+// terminal and don't know what a repository or a remote is. So these prompts do
+// two jobs: they tell the agent what to fix, and they tell it *how to talk*
+// while fixing it (one numbered step at a time, plain words, nothing assumed).
+//
+// The GitHub sign-in prompt is the important one: almost every "sync failed" a
+// designer hits is really "this computer was never signed in to GitHub", and the
+// fix is the GitHub CLI plus `gh auth login` — which the user has to type
+// themselves, so the agent must walk them all the way from "where is the
+// Terminal app" to "you can go back to Protovibe now".
+
+export type OsKind = 'macOS' | 'Windows' | 'Linux';
+
+export function detectOs(): OsKind {
+  const ua = typeof navigator === 'undefined' ? '' : navigator.userAgent;
+  if (/Mac/i.test(ua)) return 'macOS';
+  if (/Win/i.test(ua)) return 'Windows';
+  return 'Linux';
+}
+
+/**
+ * Why a git operation failed, as far as the UI needs to care.
+ *  - `auth`           GitHub/the remote refused these credentials.
+ *  - `remote-missing` the online copy of the project couldn't be found.
+ *  - `other`          anything else (merge trouble, network, unknown).
+ *
+ * All three lead to the same offer of help — a designer can't act on the
+ * difference — but the first two get a more confident on-screen sentence.
+ */
+export type GitFailureKind = 'auth' | 'remote-missing' | 'other';
+
+const AUTH_RE =
+  /permission denied|authentication failed|could not read (username|password|from remote)|terminal prompts disabled|invalid username or password|support for password authentication|publickey|access denied|access rights|unable to access|host key verification failed|\b(401|403)\b|forbidden|not granted|please tell me who you are/i;
+
+const REMOTE_MISSING_RE =
+  /repository not found|\b404\b|does not appear to be a git repository|no such remote|couldn't find remote ref|no configured push destination|no upstream|remote origin/i;
+
+export function classifyGitFailure(text: string): GitFailureKind {
+  if (REMOTE_MISSING_RE.test(text)) return 'remote-missing';
+  if (AUTH_RE.test(text)) return 'auth';
+  return 'other';
+}
+
+/** True when the failure is one the user's GitHub sign-in most likely explains. */
+export function isGithubAccessFailure(text: string): boolean {
+  const kind = classifyGitFailure(text);
+  return kind === 'auth' || kind === 'remote-missing';
+}
+
+// ---------------------------------------------------------------------------
+// shared prompt sections
+// ---------------------------------------------------------------------------
+
+// The agent has to answer the way the prompt is written — a correct fix
+// explained in jargon is a failed fix for this user.
+const TONE = `HOW TO TALK TO ME — this matters just as much as the fix:
+- I am not technical at all. Assume I have never opened a Terminal, never used GitHub, and don't know what a repository, a remote, a command line, a package manager or credentials are.
+- Explain it the way you would explain it to your grandmother: short numbered steps, everyday words, no jargon. If a technical word is unavoidable, say what it means in one plain sentence first.
+- Give me ONE step at a time, then wait for me to say "done" before giving me the next one. Please don't paste a long list of steps at once.
+- For every step, tell me exactly where to click or what to type (write the text out in full, exactly as I should type it), and tell me what I should see on screen afterwards so I know it worked.
+- If what I describe doesn't match what you expected, ask me what I can see on my screen instead of guessing.
+- Do everything you can do yourself. Only ask me to type something when it really has to be me.
+- Please don't make me feel silly for not knowing any of this.`;
+
+function installGhSection(os: OsKind): string {
+  const perOs: Record<OsKind, string> = {
+    macOS: `- If Homebrew is already installed on this Mac, use it: \`brew install gh\`
+- If Homebrew is NOT installed, please do not install Homebrew just for this — it is a big detour for me. Instead download the official standalone GitHub CLI package for macOS (the \`.pkg\` file from https://github.com/cli/cli/releases/latest) and install that.`,
+    Windows: `- If \`winget\` is available on this PC, use it: \`winget install --id GitHub.cli\`
+- If \`winget\` is NOT available, please do not install a package manager just for this. Instead download the official standalone GitHub CLI installer for Windows (the \`.msi\` file from https://github.com/cli/cli/releases/latest) and run it.`,
+    Linux: `- Prefer my distribution's official GitHub CLI package (the apt/dnf instructions at https://github.com/cli/cli/blob/trunk/docs/install_linux.md).
+- If that isn't possible, please do not install a package manager just for this. Instead download the official standalone GitHub CLI build for Linux (the \`.tar.gz\` from https://github.com/cli/cli/releases/latest) and put \`gh\` on my PATH.`,
+  };
+
+  return `STEP 1 — INSTALL THE GITHUB HELPER (please do this part yourself, don't hand it to me)
+Install the GitHub CLI — the \`gh\` command. It's the little helper that lets my computer prove to GitHub that I'm me.
+${perOs[os]}
+- When it's installed, check it yourself by running \`gh --version\`.
+- Then just tell me, in one sentence, that you installed a helper and that I only have to do the next bit.`;
+}
+
+function openTerminalSteps(os: OsKind): string {
+  const perOs: Record<OsKind, string> = {
+    macOS: `Hold down the Command key (⌘ — it's right next to the space bar) and, while holding it, press the Spacebar. A little search box appears in the middle of the screen. Type the word Terminal and press Enter. A small window full of plain text opens — that window is the Terminal.`,
+    Windows: `Press the Windows key on the keyboard (the one with the Windows logo, bottom-left, next to the space bar). A menu with a search box appears. Type the word PowerShell and press Enter. A window full of plain text opens — that window is the Terminal.`,
+    Linux: `Hold down the Ctrl key and the Alt key together and press the letter T. A window full of plain text opens — that window is the Terminal. If nothing happens, look for an app called "Terminal" in my list of applications and open it.`,
+  };
+
+  return perOs[os];
+}
+
+function signInSection(os: OsKind): string {
+  return `STEP 2 — SIGN ME IN TO GITHUB (I have to type this part myself, so please hold my hand)
+1. First, help me open the Terminal app. I honestly do not know where it is or what it looks like. Tell me this, in your own gentle words:
+   "${openTerminalSteps(os)}"
+   Then ask me to tell you when I can see that window.
+2. Ask me to click once inside that window (so it's listening to my keyboard), then type exactly this and press Enter:
+   gh auth login
+3. It will then ask me a few questions, one screen at a time. Walk me through them ONE at a time, and for each one tell me exactly which line to choose — I move up and down the list with the arrow keys and choose with the Enter key:
+   - "What account do you want to log into?" → GitHub.com
+   - "What is your preferred protocol for Git operations?" → HTTPS
+   - "Authenticate Git with your GitHub credentials?" → Yes
+   - "How would you like to authenticate GitHub CLI?" → Login with a web browser
+4. It will then show me a short code of letters and numbers (something like ABCD-1234). Tell me to write it down or copy it, then press Enter — my web browser will open a GitHub page. Then tell me to type that code into the box, click Continue, sign in to GitHub if it asks me to (or create a free GitHub account if I don't have one — walk me through that too), and finally click the green Authorize button.
+5. Back in the Terminal, ask me to type exactly this and press Enter:
+   gh auth setup-git
+   (this is the bit that lets my project actually upload — please don't skip it)
+6. Tell me when I'm finished and can close the Terminal window.`;
+}
+
+const VERIFY_SECTION = `STEP 3 — CHECK IT REALLY WORKS (your job, not mine)
+- In my project folder, run \`git push\` (or \`git fetch\` if there's nothing to send) yourself and make sure it goes through without asking for a password.
+- Also check the project is pointing at the right place online: look at \`git remote -v\`. If there's no address at all, or it points at something that no longer exists, create or point it at the right GitHub project for me — make it private — set the upstream branch for my current branch, and push.
+- If GitHub says I'm not allowed to upload to that project, explain in plain words who I should ask for access, or offer to move my work into a new private project under my own account.
+
+WHEN IT'S ALL WORKING
+Tell me in one simple sentence: "You can go back to Protovibe now and click Sync with Git again." Don't finish with a summary full of technical words — a short, friendly sentence is perfect.`;
+
+function projectLine(root: string): string {
+  return root ? `\n\nMy project folder is here: ${root}` : '';
+}
+
+function errorLine(error?: string): string {
+  return error && error.trim()
+    ? `\n\nThis is the exact error Protovibe got (I don't understand it):\n${error.trim()}`
+    : '';
+}
+
+// ---------------------------------------------------------------------------
+// prompts
+// ---------------------------------------------------------------------------
+
+function openingFor(kind: GitFailureKind, os: OsKind): string {
+  const intro = `I'm using Protovibe — a visual design tool — on ${os}. I clicked the "Sync with Git" button to save and share my work, and it failed.`;
+
+  if (kind === 'auth') {
+    return `${intro}
+
+Protovibe thinks GitHub refused to accept my work because this computer isn't signed in to GitHub. Please set up my GitHub sign-in on this computer for me, and then get my work synced.`;
+  }
+  if (kind === 'remote-missing') {
+    return `${intro}
+
+Protovibe couldn't find my project's online copy on GitHub. That usually means either this computer isn't signed in to GitHub (so GitHub pretends the project isn't there), or the project's online address is missing or wrong. Please sort both out for me, and then get my work synced.`;
+  }
+  return `${intro}
+
+I don't understand the error message. Please look at it, fix whatever is wrong with Git or GitHub on this computer, and get my work synced. If it turns out this computer simply isn't signed in to GitHub, please set that up for me as well — that's the most common reason.`;
+}
+
+/** The main "sync failed" prompt: sign this computer in to GitHub, end to end. */
+export function syncFailurePrompt(
+  kind: GitFailureKind,
+  os: OsKind,
+  root: string,
+  error?: string,
+): string {
+  return [
+    openingFor(kind, os),
+    TONE,
+    'WHAT I NEED YOU TO DO, IN ORDER',
+    installGhSection(os),
+    signInSection(os),
+    VERIFY_SECTION,
+  ].join('\n\n') + projectLine(root) + errorLine(error);
+}
+
+/** Git itself isn't on the machine yet (Protovibe normally provisions it). */
+export function installGitPrompt(os: OsKind, root: string): string {
+  return [
+    `I'm using Protovibe — a visual design tool — on ${os}, and it tells me that Git isn't installed on this computer, so I can't save and share my work with my team. Please install Git for me, and while you're there set up my GitHub sign-in too, so that syncing works the first time I try it.`,
+    TONE,
+    'WHAT I NEED YOU TO DO, IN ORDER',
+    `STEP 0 — INSTALL GIT (please do this yourself)
+Install Git on this computer using the normal way for ${os}, and check it worked by running \`git --version\`. Don't install a package manager like Homebrew just for this if it isn't already there — use the official standalone installer instead.`,
+    installGhSection(os),
+    signInSection(os),
+    VERIFY_SECTION,
+  ].join('\n\n') + projectLine(root);
+}
+
+/** No repository here yet — create one and put it on GitHub. */
+export function setupRepoPrompt(os: OsKind, root: string, error?: string): string {
+  return [
+    `I'm using Protovibe — a visual design tool — on ${os}, and I want to save my work online so I can share it with my team and not lose it. Protovibe tells me this project isn't set up for that yet. Please set the whole thing up for me: put this project under Git, create a new private project for it on my GitHub account, and upload it.`,
+    TONE,
+    'WHAT I NEED YOU TO DO, IN ORDER',
+    installGhSection(os),
+    signInSection(os),
+    `STEP 3 — SET THE PROJECT UP (your job, not mine)
+- Start version tracking in my project folder (\`git init\`), make a first save of everything that's there, create a new PRIVATE project on my GitHub account for it, connect the folder to it, set the upstream branch, and upload.
+- Tell me in one plain sentence what the project is called on GitHub and that it's private (only me and people I invite can see it).`,
+    VERIFY_SECTION,
+  ].join('\n\n') + projectLine(root) + errorLine(error);
+}
+
+/** There's a repo, but no shared online copy to sync with. */
+export function connectRemotePrompt(os: OsKind, root: string, error?: string): string {
+  return [
+    `I'm using Protovibe — a visual design tool — on ${os}. My project is under Git already, but it isn't connected to a shared online copy, so I can't sync my work with my team. Please connect it to GitHub for me and upload what I have.`,
+    TONE,
+    'WHAT I NEED YOU TO DO, IN ORDER',
+    installGhSection(os),
+    signInSection(os),
+    `STEP 3 — CONNECT THE PROJECT (your job, not mine)
+- Connect my project folder to a GitHub project — use the right existing one if my team already has it, otherwise create a new PRIVATE one on my account. Set the upstream branch for my current branch and upload my work.
+- Tell me in one plain sentence what the project is called on GitHub and who can see it.`,
+    VERIFY_SECTION,
+  ].join('\n\n') + projectLine(root) + errorLine(error);
+}

--- a/protovibe-project-template/plugins/protovibe/src/ui/utils/gitAgentPrompts.ts
+++ b/protovibe-project-template/plugins/protovibe/src/ui/utils/gitAgentPrompts.ts
@@ -152,15 +152,30 @@ Protovibe couldn't find my project's online copy on GitHub. That usually means e
 I don't understand the error message. Please look at it, fix whatever is wrong with Git or GitHub on this computer, and get my work synced. If it turns out this computer simply isn't signed in to GitHub, please set that up for me as well — that's the most common reason.`;
 }
 
+// Protovibe's GitHub connection exists but isn't allowed near this repository.
+// The obvious remedy — tick the repo on GitHub's app-installation page — is one
+// our users often can't carry out: on a company repository an owner or admin has
+// to approve it. So the prompt asks the agent to find whichever route works,
+// including the one that skips the Protovibe connection entirely (this machine
+// pushing as the user, via gh), rather than assuming a setting they can flip.
+const APP_NOT_PERMITTED = `ONE MORE THING PROTOVIBE TOLD ME
+My GitHub account is connected to Protovibe, but GitHub hasn't given Protovibe permission for this particular project. I don't know how to change that, and I may not even be allowed to — the project might belong to my company, where someone else decides these things. Please don't just tell me to go and tick a box on GitHub; I won't know which one, and it may refuse me.
+Instead, please work out which of these actually applies and take me through it:
+- If it's my own project and I can grant the permission myself, walk me through it click by click.
+- If someone else has to approve it, tell me exactly who to ask and give me the short message to send them, written so I can copy and paste it.
+- Best of all: set this computer up to upload as ME (the gh sign-in below), which doesn't depend on that permission at all. If that's enough to get my work synced, just do that and tell me it's sorted.`;
+
 /** The main "sync failed" prompt: sign this computer in to GitHub, end to end. */
 export function syncFailurePrompt(
   kind: GitFailureKind,
   os: OsKind,
   root: string,
   error?: string,
+  appNotPermitted = false,
 ): string {
   return [
     openingFor(kind, os),
+    ...(appNotPermitted ? [APP_NOT_PERMITTED] : []),
     TONE,
     'WHAT I NEED YOU TO DO, IN ORDER',
     installGhSection(os),


### PR DESCRIPTION
Sync failures left non-technical users stuck: only recognised auth errors
showed guidance, the guidance never appeared when the sync was started from
the "Someone made an update" banner, and the coding-agent prompt assumed the
user knew what a remote, a terminal or credentials were.

- Every failed op (not just classified auth errors) now shows an explanation
  plus a paste-to-your-coding-agent prompt in the Git menu — expanded when
  Protovibe has no first-line fix of its own, a quiet link when it does.
- Failures anywhere ask the Git menu to open (new pv-git-menu-open event), so
  a sync started from the banner can't end in a toast the user can't act on.
- Classify failures as auth / remote-missing / other so the headline can say
  "GitHub wouldn't accept your work" or "couldn't find your project online"
  rather than repeating raw git output; error toasts now carry the plain
  message instead of the raw stderr.
- New utils/gitAgentPrompts.ts holds every prompt, rewritten for someone who
  has never opened a terminal: it tells the agent to install the GitHub CLI
  itself (Homebrew/winget only if already present, otherwise the official
  standalone installer — never install a package manager for this), then walk
  the user through finding the Terminal app on their OS keystroke by
  keystroke, running `gh auth login` and `gh auth setup-git`, and verifying
  the push. It also instructs the agent to answer the same way: one numbered
  step at a time, plain words, waiting for confirmation before continuing.
- Menu scrolls instead of clipping, so the taller error panel can't hide the
  Sync button on a short screen.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013BwzpCssmAJq4HjXYcXH74