### PR TITLE
Stamp plugin dist with the version it was built from

### DIFF
--- a/protovibe-project-template/plugins/protovibe/package.json
+++ b/protovibe-project-template/plugins/protovibe/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "dev": "concurrently \"pnpm run watch:node\" \"pnpm run watch:ui\"",
-    "build": "tsup src/index.ts --format esm --dts && esbuild src/ui/inspector.tsx --bundle --minify --outfile=dist/ui/inspector.js && esbuild src/ui/bridge.ts --bundle --minify --outfile=dist/ui/bridge.js && esbuild src/ui/sketchpad-bridge.ts --bundle --minify --outfile=dist/ui/sketchpad-bridge.js",
+    "build": "tsup src/index.ts --format esm --dts && esbuild src/ui/inspector.tsx --bundle --minify --outfile=dist/ui/inspector.js && esbuild src/ui/bridge.ts --bundle --minify --outfile=dist/ui/bridge.js && esbuild src/ui/sketchpad-bridge.ts --bundle --minify --outfile=dist/ui/sketchpad-bridge.js && node scripts/write-build-info.js",
     "watch:node": "tsup src/index.ts --format esm --dts --watch",
     "watch:ui": "node scripts/watch-ui.js"
   },

--- a/protovibe-project-template/plugins/protovibe/scripts/write-build-info.js
+++ b/protovibe-project-template/plugins/protovibe/scripts/write-build-info.js
@@ -1,0 +1,23 @@
+// Stamps dist/ with the plugin version it was built from.
+//
+// dist/ is gitignored, so a project synced from Git receives new plugin SOURCE
+// on top of whatever dist was last built on that machine. Running the project
+// through the manager reconciles that (its `pnpm install` runs the root
+// postinstall, which wipes and rebuilds dist), but until then the two disagree
+// — and nothing else on disk records which source dist actually came from.
+// This file is that record: read it to tell a stale build from a fresh one.
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const pluginDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const { version } = JSON.parse(fs.readFileSync(path.join(pluginDir, 'package.json'), 'utf-8'));
+const distDir = path.join(pluginDir, 'dist');
+
+fs.mkdirSync(distDir, { recursive: true });
+fs.writeFileSync(
+  path.join(distDir, 'build-info.json'),
+  JSON.stringify({ version, builtAt: new Date().toISOString() }, null, 2) + '\n',
+  'utf-8',
+);
+console.log(`[protovibe] dist stamped with plugin v${version}`);


### PR DESCRIPTION
plugins/protovibe/dist is gitignored, so a project synced from Git receives new
editor source on top of whatever dist was last built on that machine. Running
the project reconciles this — the manager's Run path goes through /setup, whose
`pnpm install` runs the root postinstall, which wipes and rebuilds dist on every
launch — but between a sync and that next run the two disagree, and a project
already running keeps serving the dist it booted with. Nothing on disk recorded
which source dist actually came from, so that state was invisible.

The build now writes dist/build-info.json with the version it was built from.
No behaviour is gated on it: it's a record, for telling a stale build from a
fresh one.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CVXLsBSS3tsuSPfcLeP8eT