### PR TITLE
Switch release checks to unauthenticated GitHub endpoints

### DIFF
--- a/electron/src/toolchain.js
+++ b/electron/src/toolchain.js
@@ -55,6 +55,10 @@ function buildChildEnv(extra = {}) {
   // Lets the manager adapt when running under the desktop shell (e.g. the
   // OAuth callback page offers a protovibe:// link back to the app).
   env.PROTOVIBE_SHELL = '1';
+  // The shell's own version, so the manager's version popover can show it
+  // alongside the manager/template versions. Absent outside the shell, which is
+  // how the popover knows to hide that row.
+  env.PROTOVIBE_SHELL_VERSION = require('../package.json').version;
   // Point the manager's git resolver at the bundled, signed+notarized git tree
   // so it never downloads git at runtime or falls back to the Xcode CLT stub.
   // Only set in the packaged app; dev has no bundled tree and uses system git.

--- a/protovibe-project-manager/src/components/VersionInfoMenu.jsx
+++ b/protovibe-project-manager/src/components/VersionInfoMenu.jsx
@@ -8,12 +8,14 @@ export default function VersionInfoMenu({ onUpdateClick }) {
   const [error, setError] = useState('')
   const ref = useRef(null)
 
-  const check = useCallback(async () => {
+  // `force` drives ?refresh=1, which bypasses the server's result cache. Without
+  // it "Try again" replayed the cached failure and looked like a dead button.
+  const check = useCallback(async (force = false) => {
     setLoading(true)
     setError('')
     try {
-      const res = await fetch('/api/version')
-      if (!res.ok) throw new Error('Request failed')
+      const res = await fetch(`/api/version${force ? '?refresh=1' : ''}`, { cache: 'no-store' })
+      if (!res.ok) throw new Error(`Version check failed (${res.status})`)
       const data = await res.json()
       setInfo(data)
       return data
@@ -24,6 +26,8 @@ export default function VersionInfoMenu({ onUpdateClick }) {
       setLoading(false)
     }
   }, [])
+
+  const retry = useCallback(() => check(true), [check])
 
   useEffect(() => {
     let cancelled = false
@@ -57,24 +61,31 @@ export default function VersionInfoMenu({ onUpdateClick }) {
     })
   }
 
-  const outdated = info && (info.manager?.outdated || info.template?.outdated)
-  const fetchFailed = info && (info.manager?.error || info.template?.error)
-  const allUpToDate = info && !fetchFailed && !outdated
+  // Only the source (manager/template) drives the download button — the shell
+  // installs its own updates through electron-updater.
+  const sourceOutdated = info && (info.manager?.outdated || info.template?.outdated)
+  const shellOutdated = info?.shell?.outdated
+  const anyOutdated = sourceOutdated || shellOutdated
+  // Distinct reasons, deduped: the manager and template share one source error.
+  const failures = info
+    ? [...new Set([info.manager?.error, info.template?.error, info.shell?.error].filter(Boolean))]
+    : []
+  const allUpToDate = info && failures.length === 0 && !anyOutdated
 
   return (
     <div ref={ref} className="relative">
       <button
         onClick={handleToggle}
         className={`relative flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
-          outdated
+          anyOutdated
             ? 'bg-primary text-foreground-on-primary hover:bg-primary-hover'
             : 'bg-background-secondary text-foreground-default hover:bg-background-tertiary'
         }`}
       >
-        {outdated ? <Download size={14} /> : null}
-        {outdated ? 'Update available' : 'Version info'}
+        {anyOutdated ? <Download size={14} /> : null}
+        {anyOutdated ? 'Update available' : 'Version info'}
         <ChevronDown size={12} className={`transition-transform ${open ? 'rotate-180' : ''}`} />
-        {outdated && (
+        {anyOutdated && (
           <span className="absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full bg-foreground-destructive border-2 border-background-elevated" />
         )}
       </button>
@@ -91,24 +102,25 @@ export default function VersionInfoMenu({ onUpdateClick }) {
           {!loading && error && (
             <div className="flex flex-col gap-2">
               <p className="text-xs text-foreground-destructive">{error}</p>
-              <button
-                onClick={check}
-                className="text-xs text-foreground-secondary hover:text-foreground-default self-start cursor-pointer"
-              >
-                Try again
-              </button>
+              <RetryButton onClick={retry} />
             </div>
           )}
 
           {!loading && !error && info && (
             <>
+              {info.shell && (
+                <>
+                  <VersionRow label="Protovibe app" data={info.shell} />
+                  <div className="h-px bg-border-default" />
+                </>
+              )}
               <VersionRow label="Project manager" data={info.manager} />
               <div className="h-px bg-border-default" />
               <VersionRow label="Project template" data={info.template} />
 
               <div className="h-px bg-border-default" />
 
-              {outdated && (
+              {sourceOutdated && (
                 <div className="flex flex-col gap-2">
                   <p className="text-xs text-foreground-secondary">
                     Each of your projects picks up the new Protovibe editor the next time you run it.
@@ -123,25 +135,36 @@ export default function VersionInfoMenu({ onUpdateClick }) {
                 </div>
               )}
 
-              {!outdated && allUpToDate && (
+              {/* The shell has no button of its own: electron-updater downloads it
+                  in the background and prompts to restart when it's ready. */}
+              {shellOutdated && (
+                <p className="text-xs text-foreground-secondary">
+                  Protovibe {info.shell.latest} is available. The app downloads it on its
+                  own and will ask you to restart when it's ready to install.
+                </p>
+              )}
+
+              {allUpToDate && (
                 <div className="flex items-center gap-1.5 text-xs text-foreground-secondary">
                   <Check size={12} />
                   You have the newest version
                 </div>
               )}
 
-              {!outdated && fetchFailed && (
+              {failures.length > 0 && (
                 <div className="flex flex-col gap-2">
                   <div className="flex items-start gap-1.5 text-xs text-foreground-destructive">
                     <AlertCircle size={12} className="mt-0.5 shrink-0" />
-                    <span>Couldn't reach GitHub to check for updates.</span>
+                    <div className="flex flex-col gap-1">
+                      <span>Couldn't check for updates.</span>
+                      {/* Verbatim so a rate limit, a TLS failure and a 404 are
+                          told apart instead of all reading "couldn't reach GitHub". */}
+                      {failures.map((f) => (
+                        <span key={f} className="font-mono text-[10px] leading-snug break-words text-foreground-tertiary">{f}</span>
+                      ))}
+                    </div>
                   </div>
-                  <button
-                    onClick={check}
-                    className="text-xs text-foreground-secondary hover:text-foreground-default self-start cursor-pointer"
-                  >
-                    Try again
-                  </button>
+                  <RetryButton onClick={retry} />
                 </div>
               )}
             </>
@@ -149,6 +172,17 @@ export default function VersionInfoMenu({ onUpdateClick }) {
         </div>
       )}
     </div>
+  )
+}
+
+function RetryButton({ onClick }) {
+  return (
+    <button
+      onClick={onClick}
+      className="text-xs text-foreground-secondary hover:text-foreground-default self-start cursor-pointer"
+    >
+      Try again
+    </button>
   )
 }
 

--- a/protovibe-project-manager/src/components/VersionInfoMenu.jsx
+++ b/protovibe-project-manager/src/components/VersionInfoMenu.jsx
@@ -187,7 +187,9 @@ function RetryButton({ onClick }) {
 }
 
 function VersionRow({ label, data }) {
-  const current = data?.current ?? '—'
+  // A null `current` means "running, but this build can't report its version"
+  // (an Electron shell older than PROTOVIBE_SHELL_VERSION) — not "not installed".
+  const current = data?.current ?? null
   const latest = data?.latest
   const error = data?.error
   const sameVersion = latest && current && latest === current
@@ -205,7 +207,11 @@ function VersionRow({ label, data }) {
         <>
           <div className="flex items-center justify-between text-xs text-foreground-secondary">
             <span>Installed</span>
-            <span className="font-mono text-foreground-default">{current}</span>
+            {current ? (
+              <span className="font-mono text-foreground-default">{current}</span>
+            ) : (
+              <span className="text-foreground-tertiary italic" title="This build is too old to report its version.">unknown</span>
+            )}
           </div>
           <div className="flex items-center justify-between text-xs text-foreground-secondary">
             <span>Latest in repo</span>

--- a/protovibe-project-manager/vite.config.js
+++ b/protovibe-project-manager/vite.config.js
@@ -13,7 +13,6 @@ import {
   handleStatus as handleGithubStatus,
   handleLogout as handleGithubLogout,
   readStoredAuth,
-  storedGithubToken,
 } from './server/github-auth.js'
 import { handleListRepos, handleValidateRepo } from './server/github-api.js'
 import { resolveGit, ensureEmbeddedGit, handleClone } from './server/git-engine.js'
@@ -346,6 +345,8 @@ function sendJson(res, status, data) {
     'Content-Type': 'application/json',
     'Content-Length': Buffer.byteLength(body),
     'Access-Control-Allow-Origin': '*',
+    // These are all live state; a cached 200 made "Try again" a no-op.
+    'Cache-Control': 'no-store',
   })
   res.end(body)
 }
@@ -1222,161 +1223,226 @@ function semverGt(a, b) {
   return false
 }
 
-// Cache so we only shell out to `gh` once per dev-server lifetime.
-let cachedGhToken = null
-function githubToken() {
-  const env = process.env.PROTOVIBE_GITHUB_TOKEN || process.env.GITHUB_TOKEN
-  if (env) return env
-  // Token stored by the "Connect to GitHub" flow.
-  const stored = storedGithubToken()
-  if (stored) return stored
-  if (cachedGhToken !== null) return cachedGhToken
-  try {
-    // shell:true on Windows so `gh.cmd` / `gh.exe` resolves via PATHEXT.
-    const out = execFileSync('gh', ['auth', 'token'], {
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-      shell: process.platform === 'win32',
-    }).trim()
-    cachedGhToken = out || ''
-  } catch {
-    cachedGhToken = ''
-  }
-  return cachedGhToken
-}
-
 // ── Signed release fetch/verify ──────────────────────────────────────────────
 // Auto-updates come from a GitHub Release (tag `source-v*`) carrying three
 // assets: the source bundle zip, `manifest.json`, and `manifest.json.sig`. The
 // manifest is verified against the embedded Ed25519 public key before ANY of its
 // contents (versions, artifact name, artifact hash) are trusted. A compromise of
 // the git repo alone cannot forge a release without the offline signing key.
+//
+// Everything here goes over plain `github.com` — never `api.github.com`. The API
+// costs 60 requests/hour/IP unauthenticated (a budget a shared VPN exit IP has
+// usually already spent) and needed a token to raise, which meant a stale stored
+// token could 401 the check permanently. The endpoints below need no token and
+// are not on that budget — they are the same ones electron-updater already uses
+// successfully. The trade-off is that they require the repo to stay public.
 
-function githubApiHeaders(accept = 'application/vnd.github+json') {
-  const headers = { Accept: accept, 'User-Agent': 'protovibe-project-manager' }
-  const token = githubToken()
-  if (token) headers.Authorization = `Bearer ${token}`
-  return headers
+const GITHUB_HEADERS = { 'User-Agent': 'protovibe-project-manager' }
+
+function releaseDownloadUrl(tag, name) {
+  return `https://github.com/${REMOTE_REPO}/releases/download/${encodeURIComponent(tag)}/${encodeURIComponent(name)}`
 }
 
-// Fetch a release asset's raw bytes. The API asset URL + octet-stream Accept
-// works for both public and private repos (with a token).
-async function fetchAssetBytes(asset, timeoutMs = 15000) {
-  if (!asset?.url) throw new Error('Release asset is missing its download URL.')
-  const res = await fetch(asset.url, {
-    headers: githubApiHeaders('application/octet-stream'),
+// Fetch one published release asset. Returns null on 404 so callers can walk
+// down to an older tag: `scripts/release.mjs` pushes a tag BEFORE the signing
+// workflow is approved, so the newest tag may have no assets yet.
+async function fetchReleaseAsset(tag, name, timeoutMs = 15000) {
+  const res = await fetch(releaseDownloadUrl(tag, name), {
+    headers: GITHUB_HEADERS,
     redirect: 'follow',
     signal: AbortSignal.timeout(timeoutMs),
   })
-  if (!res.ok) throw new Error(`Failed to download ${asset.name}: GitHub returned ${res.status}`)
+  if (res.status === 404) return null
+  if (!res.ok) throw new Error(`Failed to download ${name} from ${tag}: GitHub returned ${res.status}`)
   return Buffer.from(await res.arrayBuffer())
 }
 
-// Parse the semver out of a `source-vX.Y.Z` tag. Returns null for tags that are
-// not strictly `source-v` + a three-part numeric version (e.g. the malformed
-// `source-vtemplate`), so junk releases can never be selected as "latest".
-function releaseTagVersion(tagName) {
+// Parse the version out of a `source-vX.Y.Z` tag, optionally with the `-rN`
+// re-release suffix that scripts/release.mjs appends when a tag is re-cut
+// without a version bump — which is what a template-only release produces.
+// Returns null for anything else (e.g. the malformed `source-v` tag in this
+// repo's history) so junk tags can never be selected as "latest".
+function parseSourceTag(tagName) {
   if (typeof tagName !== 'string' || !tagName.startsWith(RELEASE_TAG_PREFIX)) return null
-  const rest = tagName.slice(RELEASE_TAG_PREFIX.length)
-  return /^\d+\.\d+\.\d+$/.test(rest) ? rest : null
+  const m = tagName.slice(RELEASE_TAG_PREFIX.length).match(/^(\d+)\.(\d+)\.(\d+)(?:-r(\d+))?$/)
+  if (!m) return null
+  return {
+    tag: tagName,
+    version: `${m[1]}.${m[2]}.${m[3]}`,
+    // An unsuffixed tag is revision 1; `-r2` is the second cut of that version.
+    parts: [Number(m[1]), Number(m[2]), Number(m[3]), m[4] ? Number(m[4]) : 1],
+  }
 }
 
-// Locate the newest signed source release and verify its manifest. Returns
-// { manifest, release, assetsByName } on success. Throws on network failure, a
-// missing/invalid signature, or when no signed source release exists — callers
-// must let that error surface so an unverified update is never applied.
-async function fetchSignedRelease() {
-  const res = await fetch(`https://api.github.com/repos/${REMOTE_REPO}/releases?per_page=30`, {
-    headers: githubApiHeaders(),
+function compareParts(a, b) {
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const x = a[i] || 0, y = b[i] || 0
+    if (x !== y) return x < y ? -1 : 1
+  }
+  return 0
+}
+
+// List every `source-v*` tag via git's unauthenticated smart-HTTP ref
+// advertisement. This is how we find the newest release without the API: one
+// ~10KB request, no token, no rate-limit budget. The tag list is only a hint
+// about where to look — nothing from it is trusted until the manifest fetched
+// at that tag passes signature verification below.
+async function fetchSourceTags() {
+  const res = await fetch(`https://github.com/${REMOTE_REPO}.git/info/refs?service=git-upload-pack`, {
+    headers: GITHUB_HEADERS,
     signal: AbortSignal.timeout(10000),
   })
-  if (!res.ok) {
-    // Distinguish GitHub's rate limit (very common when the app checks
-    // unauthenticated — 60 req/hr/IP) from a generic failure so the UI can tell
-    // the user to retry later rather than implying the network is down.
-    const remaining = res.headers.get('x-ratelimit-remaining')
-    if ((res.status === 403 || res.status === 429) && remaining === '0') {
-      throw new Error('GitHub API rate limit reached — connect GitHub or try again later.')
-    }
-    throw new Error(`GitHub returned ${res.status} listing releases`)
+  if (!res.ok) throw new Error(`GitHub returned ${res.status} listing tags`)
+  const body = await res.text()
+  // `refs/tags/<name>` and the peeled `refs/tags/<name>^{}` both appear; the Map
+  // dedupes them since only the name matters here.
+  const seen = new Map()
+  for (const m of body.matchAll(/refs\/tags\/(\S+?)(?:\^\{\})?[\s\0]/g)) {
+    const parsed = parseSourceTag(m[1])
+    if (parsed) seen.set(parsed.tag, parsed)
   }
-  const releases = await res.json()
-  // Consider only published (non-draft, non-prerelease) source releases whose
-  // tag is a strict `source-vX.Y.Z` and that carry both manifest assets, then
-  // pick the HIGHEST version — never rely on GitHub's list order, and never let
-  // a malformed tag like `source-vtemplate` win.
-  const release = (Array.isArray(releases) ? releases : [])
-    .filter((r) =>
-      !r.draft && !r.prerelease &&
-      releaseTagVersion(r.tag_name) &&
-      (r.assets || []).some((a) => a.name === 'manifest.json') &&
-      (r.assets || []).some((a) => a.name === 'manifest.json.sig'),
-    )
-    .sort((a, b) => (semverGt(releaseTagVersion(a.tag_name), releaseTagVersion(b.tag_name)) ? -1 : 1))[0]
-  if (!release) throw new Error('No signed source release found.')
+  return [...seen.values()].sort((a, b) => compareParts(b.parts, a.parts))
+}
 
-  const assetsByName = new Map((release.assets || []).map((a) => [a.name, a]))
-  const [manifestBuf, sigBuf] = await Promise.all([
-    fetchAssetBytes(assetsByName.get('manifest.json')),
-    fetchAssetBytes(assetsByName.get('manifest.json.sig')),
-  ])
-  // Throws unless the signature verifies against the embedded public key.
-  const manifest = verifyManifest(manifestBuf, sigBuf.toString('utf-8'))
-  return { manifest, release, assetsByName }
+// How many tags deep to look for a published release before giving up. Covers
+// the normal case of a tag or two pushed but not yet approved for signing.
+const RELEASE_LOOKBACK = 3
+
+// Locate the newest signed source release and verify its manifest. Returns
+// { manifest, tag } on success. Throws on network failure, a missing/invalid
+// signature, or when no signed source release exists — callers must let that
+// error surface so an unverified update is never applied.
+async function fetchSignedRelease() {
+  const tags = await fetchSourceTags()
+  if (tags.length === 0) throw new Error('No signed source release found.')
+
+  for (const candidate of tags.slice(0, RELEASE_LOOKBACK)) {
+    const [manifestBuf, sigBuf] = await Promise.all([
+      fetchReleaseAsset(candidate.tag, 'manifest.json'),
+      fetchReleaseAsset(candidate.tag, 'manifest.json.sig'),
+    ])
+    // Tag exists but its release isn't published (or isn't signed) yet — the
+    // expected state between `npm run release` and approving the workflow.
+    if (!manifestBuf || !sigBuf) continue
+    // A tag whose signature does NOT verify must throw rather than fall through
+    // to an older tag: silently preferring an older release would let a bad one
+    // hide a good one.
+    const manifest = verifyManifest(manifestBuf, sigBuf.toString('utf-8'))
+    return { manifest, tag: candidate.tag }
+  }
+  throw new Error('No signed source release found.')
+}
+
+// ── Electron shell version ───────────────────────────────────────────────────
+// The shell updates itself via electron-updater, independently of the source
+// tree above. We only *report* its version here so the popover can show all
+// three side by side; the "Download new version" button never touches it.
+// `latest-mac.yml` on the `latest` release is exactly what electron-updater
+// reads, so what we display is what it would actually install.
+
+const SHELL_CHANNEL_FILE = 'latest-mac.yml'
+
+// Injected by electron/src/toolchain.js. Absent when the manager runs outside
+// the desktop shell (plain `pnpm dev`), where there is no shell to report.
+function installedShellVersion() {
+  return process.env.PROTOVIBE_SHELL_VERSION || null
+}
+
+async function fetchLatestShellVersion() {
+  const res = await fetch(
+    `https://github.com/${REMOTE_REPO}/releases/latest/download/${SHELL_CHANNEL_FILE}`,
+    { headers: GITHUB_HEADERS, redirect: 'follow', signal: AbortSignal.timeout(10000) },
+  )
+  if (!res.ok) throw new Error(`GitHub returned ${res.status} fetching ${SHELL_CHANNEL_FILE}`)
+  // Minimal YAML read: the channel file's `version:` is a plain top-level
+  // scalar, so a full parser would be dead weight here.
+  const m = (await res.text()).match(/^version:\s*(.+?)\s*$/m)
+  if (!m) throw new Error(`${SHELL_CHANNEL_FILE} has no version field`)
+  return m[1].replace(/^['"]|['"]$/g, '')
 }
 
 // Cache the verified remote manifest so repeatedly opening the version menu
-// doesn't hit GitHub every time. Unauthenticated checks share a 60 req/hr/IP
-// budget and each check costs several calls, so without this the UI quickly
-// rate-limits itself into "Couldn't reach GitHub". A successful result is
-// cached longer than a failure so transient errors clear quickly.
+// doesn't refetch from GitHub every time. A successful result is cached longer
+// than a failure so transient errors clear quickly. An explicit "Try again"
+// (?refresh=1) bypasses this entirely — without that, the retry button silently
+// replayed the cached error and looked broken.
 let versionCache = { manifest: null, error: null, at: 0 }
+let shellCache = { latest: null, error: null, at: 0 }
 const VERSION_CACHE_OK_MS = 10 * 60 * 1000
-const VERSION_CACHE_ERR_MS = 60 * 1000
+const VERSION_CACHE_ERR_MS = 10 * 1000
 
-async function handleGetVersion(_req, res) {
+function cacheIsFresh(cache) {
+  const ttl = cache.error ? VERSION_CACHE_ERR_MS : VERSION_CACHE_OK_MS
+  return cache.at > 0 && Date.now() - cache.at < ttl
+}
+
+// Errors are reported to the UI verbatim (see below) and logged here too — a
+// generic "couldn't reach GitHub" left no way to tell a rate limit from a dead
+// token from a TLS failure, which made this impossible to diagnose remotely.
+function logVersionError(what, e) {
+  console.error(`[protovibe-version] ${what} check failed: ${e?.message || e}`)
+}
+
+async function refreshSourceVersions(force) {
+  if (!force && cacheIsFresh(versionCache)) return
+  try {
+    const { manifest } = await fetchSignedRelease()
+    versionCache = { manifest, error: null, at: Date.now() }
+  } catch (e) {
+    // Fail closed: on any verification/network problem we report the error and
+    // never mark anything "outdated", so the UI never offers an unverified update.
+    logVersionError('source', e)
+    versionCache = { manifest: null, error: e?.message || 'Could not verify latest release', at: Date.now() }
+  }
+}
+
+async function refreshShellVersion(force) {
+  if (!force && cacheIsFresh(shellCache)) return
+  try {
+    shellCache = { latest: await fetchLatestShellVersion(), error: null, at: Date.now() }
+  } catch (e) {
+    logVersionError('shell', e)
+    shellCache = { latest: null, error: e?.message || 'Could not read the latest shell release', at: Date.now() }
+  }
+}
+
+async function handleGetVersion(req, res, url) {
   const managerCurrent = readLocalVersion(path.join(ROOT, 'package.json'))
   const templateCurrent = readLocalVersion(path.join(TEMPLATE_DIR, 'package.json'))
+  const shellCurrent = installedShellVersion()
 
-  let managerLatest = null
-  let templateLatest = null
-  let error = null
+  const force = url?.searchParams.get('refresh') === '1'
+  // The shell check is independent of the source check, so one failing must not
+  // hide the other's result.
+  await Promise.all([refreshSourceVersions(force), refreshShellVersion(force)])
 
-  const age = Date.now() - versionCache.at
-  const ttl = versionCache.error ? VERSION_CACHE_ERR_MS : VERSION_CACHE_OK_MS
-  const fresh = versionCache.at > 0 && age < ttl
-
-  if (!fresh) {
-    try {
-      const { manifest } = await fetchSignedRelease()
-      versionCache = { manifest, error: null, at: Date.now() }
-    } catch (e) {
-      // Fail closed: on any verification/network problem we report the error and
-      // never mark anything "outdated", so the UI never offers an unverified update.
-      versionCache = { manifest: null, error: e?.message || 'Could not verify latest release', at: Date.now() }
-    }
-  }
-
-  if (versionCache.manifest) {
-    const manifest = versionCache.manifest
-    managerLatest = typeof manifest.managerVersion === 'string' ? manifest.managerVersion : null
-    templateLatest = typeof manifest.templateVersion === 'string' ? manifest.templateVersion : null
-  } else {
-    error = versionCache.error
-  }
+  const manifest = versionCache.manifest
+  const sourceError = manifest ? null : versionCache.error
+  const managerLatest = typeof manifest?.managerVersion === 'string' ? manifest.managerVersion : null
+  const templateLatest = typeof manifest?.templateVersion === 'string' ? manifest.templateVersion : null
 
   sendJson(res, 200, {
     manager: {
       current: managerCurrent,
       latest: managerLatest,
-      error,
+      error: sourceError,
       outdated: semverGt(managerLatest, managerCurrent),
     },
     template: {
       current: templateCurrent,
       latest: templateLatest,
-      error,
+      error: sourceError,
       outdated: semverGt(templateLatest, templateCurrent),
+    },
+    // null when not running under the desktop shell — the UI hides the row.
+    shell: shellCurrent === null ? null : {
+      current: shellCurrent,
+      latest: shellCache.latest,
+      error: shellCache.latest ? null : shellCache.error,
+      // Reported only. The shell installs its own updates via electron-updater,
+      // so this never drives the "Download new version" button.
+      outdated: semverGt(shellCache.latest, shellCurrent),
+      selfUpdating: true,
     },
   })
 }
@@ -1391,9 +1457,10 @@ let updateInProgress = false
 // Download a release asset to disk and verify its SHA-256 against the value from
 // the (already signature-verified) manifest. Throws before writing nothing usable
 // if the digest does not match, so tampered/corrupt artifacts never get extracted.
-async function downloadVerifiedArtifact(asset, destPath, expectedSha256, log) {
-  log(`Downloading verified release artifact ${asset.name} ...`)
-  const buf = await fetchAssetBytes(asset, 120000)
+async function downloadVerifiedArtifact(tag, name, destPath, expectedSha256, log) {
+  log(`Downloading verified release artifact ${name} ...`)
+  const buf = await fetchReleaseAsset(tag, name, 120000)
+  if (!buf) throw new Error(`Release ${tag} has no asset named "${name}".`)
   const got = sha256Hex(buf)
   const want = String(expectedSha256 || '').toLowerCase()
   if (!want || got.toLowerCase() !== want) {
@@ -1517,7 +1584,7 @@ async function runUpdate(which, log) {
 
   // Verify the signed release manifest BEFORE downloading or touching anything.
   // Throws (aborting the update) if the key is unconfigured or the signature is bad.
-  const { manifest, assetsByName } = await fetchSignedRelease()
+  const { manifest, tag: releaseTag } = await fetchSignedRelease()
   const remotePmVer = typeof manifest.managerVersion === 'string' ? manifest.managerVersion : null
   const remoteTplVer = typeof manifest.templateVersion === 'string' ? manifest.templateVersion : null
 
@@ -1540,10 +1607,9 @@ async function runUpdate(which, log) {
 
     // Download + hash-verify the artifact named in the (signed) manifest.
     const artifactName = typeof manifest.artifact === 'string' ? manifest.artifact : null
-    const artifactAsset = artifactName ? assetsByName.get(artifactName) : null
-    if (!artifactAsset) throw new Error(`Signed manifest references missing artifact "${artifactName}".`)
+    if (!artifactName) throw new Error('Signed manifest does not name an artifact.')
     const zipPath = path.join(tmp, 'source.zip')
-    await downloadVerifiedArtifact(artifactAsset, zipPath, manifest.artifactSha256, log)
+    await downloadVerifiedArtifact(releaseTag, artifactName, zipPath, manifest.artifactSha256, log)
 
     const extractDir = path.join(tmp, 'extract')
     fs.mkdirSync(extractDir, { recursive: true })
@@ -1858,7 +1924,7 @@ function projectManagerPlugin() {
             return await handleCreateProject(req, res)
           }
           if (method === 'GET' && pathname === '/version') {
-            return await handleGetVersion(req, res)
+            return await handleGetVersion(req, res, url)
           }
           if (method === 'POST' && pathname === '/projects/import') {
             return await handleImportProject(req, res, url)

--- a/protovibe-project-manager/vite.config.js
+++ b/protovibe-project-manager/vite.config.js
@@ -1342,8 +1342,17 @@ async function fetchSignedRelease() {
 
 const SHELL_CHANNEL_FILE = 'latest-mac.yml'
 
-// Injected by electron/src/toolchain.js. Absent when the manager runs outside
-// the desktop shell (plain `pnpm dev`), where there is no shell to report.
+// PROTOVIBE_SHELL has been set by the shell for far longer than
+// PROTOVIBE_SHELL_VERSION has, so it — not the version — decides whether there
+// is a shell to report at all. Keying off the version would hide the row on any
+// shell built before that variable existed, which is exactly the shell this code
+// reaches first: the in-app updater ships the manager independently of the shell.
+function runningInShell() {
+  return process.env.PROTOVIBE_SHELL === '1'
+}
+
+// Injected by electron/src/toolchain.js. Null on a shell predating that, where
+// we can still report what the latest release is but not what is installed.
 function installedShellVersion() {
   return process.env.PROTOVIBE_SHELL_VERSION || null
 }
@@ -1435,12 +1444,15 @@ async function handleGetVersion(req, res, url) {
       outdated: semverGt(templateLatest, templateCurrent),
     },
     // null when not running under the desktop shell — the UI hides the row.
-    shell: shellCurrent === null ? null : {
+    shell: !runningInShell() ? null : {
+      // null on a shell too old to report itself; the UI shows "unknown" rather
+      // than dropping the row, so the latest release is still visible.
       current: shellCurrent,
       latest: shellCache.latest,
       error: shellCache.latest ? null : shellCache.error,
       // Reported only. The shell installs its own updates via electron-updater,
-      // so this never drives the "Download new version" button.
+      // so this never drives the "Download new version" button. semverGt is
+      // false for a null current, so an unknown version never claims outdated.
       outdated: semverGt(shellCache.latest, shellCurrent),
       selfUpdating: true,
     },


### PR DESCRIPTION
## Summary

Refactors the release update mechanism to use GitHub's unauthenticated smart-HTTP git endpoints instead of the REST API. This eliminates dependency on stored authentication tokens and avoids the 60 req/hr/IP rate limit that affects unauthenticated API calls.

## Key Changes

- **Removed token-based authentication**: Deleted `githubToken()` function and `storedGithubToken` import; no longer attempts to use stored or environment GitHub tokens for release checks
- **Switched to git smart-HTTP refs**: `fetchSourceTags()` now reads the tag list from `github.com/<repo>.git/info/refs?service=git-upload-pack` (~10KB, no rate limit) instead of the REST API
- **Simplified release discovery**: Replaced REST API release listing with direct tag parsing; added `parseSourceTag()` to extract version and re-release suffix (`-rN`) from tag names
- **Direct asset downloads**: `fetchReleaseAsset()` now constructs download URLs directly (`github.com/<repo>/releases/download/<tag>/<name>`) instead of using API asset objects
- **Added shell version tracking**: New `fetchLatestShellVersion()` reads the electron-updater channel file; added `installedShellVersion()` and `runningInShell()` helpers
- **Improved caching and retry**: Separated source and shell version caches; added `?refresh=1` query parameter to bypass cache on explicit retry; added `Cache-Control: no-store` header to version endpoint
- **Enhanced error reporting**: Errors now logged with context; UI displays verbatim error messages so users can distinguish rate limits from network failures
- **Updated UI**: Version menu now shows shell version alongside manager/template; "Try again" button properly bypasses cache; shell updates noted as self-updating via electron-updater

## Implementation Details

- Tag comparison uses a new `compareParts()` function that handles version tuples including the re-release suffix
- `RELEASE_LOOKBACK = 3` allows checking up to 3 tags deep for a published release (covers the window between tag push and signing workflow approval)
- Shell version reporting is conditional: only shown when `PROTOVIBE_SHELL=1`; gracefully handles old shells that predate `PROTOVIBE_SHELL_VERSION` by showing "unknown"
- Manifest verification still required before any release is trusted; signature check now happens after tag discovery rather than as part of API listing

https://claude.ai/code/session_015EjQBFhHrAGQFTpQyhWEFE