### PR TITLE
Preserve native copy/cut when text is selected

### DIFF
--- a/protovibe-project-template/plugins/protovibe/src/ui/hooks/useKeyboardShortcuts.ts
+++ b/protovibe-project-template/plugins/protovibe/src/ui/hooks/useKeyboardShortcuts.ts
@@ -16,7 +16,7 @@ import {
   getAllowedChildren,
   getAllowedSibling,
 } from '../utils/traversal';
-import { isTypingInput } from '../utils/elementType';
+import { isTypingInput, hasTextSelectionInFocusedDocument } from '../utils/elementType';
 
 export function useKeyboardShortcuts() {
   const { 
@@ -184,6 +184,13 @@ export function useKeyboardShortcuts() {
         return;
       }
       if ((e.metaKey || e.ctrlKey) && (key === 'c' || key === 'x' || key === 'd')) {
+        // If the user has text selected (e.g. a comment or a code reference in
+        // the shell UI), let the browser perform its native copy/cut instead
+        // of copying the focused block. Only when nothing is selected does
+        // Cmd+C / Cmd+X act on the block.
+        if (key !== 'd' && hasTextSelectionInFocusedDocument()) {
+          return;
+        }
         e.preventDefault();
         const targets = selectedTargets?.length > 0 ? selectedTargets : (currentBaseTarget ? [currentBaseTarget] : []);
         const blockIds = [...new Set(

--- a/protovibe-project-template/plugins/protovibe/src/ui/utils/elementType.ts
+++ b/protovibe-project-template/plugins/protovibe/src/ui/utils/elementType.ts
@@ -54,3 +54,29 @@ export function isTypingInput(element: HTMLElement | null): boolean {
   }
   return element.tagName === 'TEXTAREA' || element.tagName === 'SELECT' || element.isContentEditable;
 }
+
+/**
+ * Returns true when the document that currently has keyboard focus (the shell
+ * document, or a same-origin iframe if it is the active element) has a
+ * non-empty text selection. Used to let native Cmd+C / Cmd+X copy selected
+ * text instead of being hijacked by the block copy/cut shortcut.
+ *
+ * Only the focused document is inspected: clicking inside the canvas iframe
+ * does not clear the parent document's selection, so a stale shell selection
+ * must not override a block copy after the user clicked a block.
+ */
+export function hasTextSelectionInFocusedDocument(): boolean {
+  try {
+    const active = document.activeElement;
+    let selection: Selection | null = null;
+    if (active && active.tagName === 'IFRAME') {
+      selection = (active as HTMLIFrameElement).contentWindow?.getSelection() ?? null;
+    } else {
+      selection = window.getSelection();
+    }
+    if (!selection || selection.isCollapsed) return false;
+    return selection.toString().trim().length > 0;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
This change allows native browser copy and cut operations to work when the user has text selected in the focused document, while preserving the block-level copy/cut/duplicate shortcuts when no text is selected.

## Key Changes
- Added `hasTextSelectionInFocusedDocument()` utility function that checks if the currently focused document (shell or same-origin iframe) has a non-empty text selection
- Updated keyboard shortcut handler to skip block copy/cut operations when text is selected, allowing the browser's native copy/cut to proceed
- The duplicate shortcut (Cmd+D) is unaffected and continues to work regardless of text selection

## Implementation Details
- The new utility function safely handles both the main document and iframe contexts by checking `document.activeElement` and accessing the iframe's `contentWindow` when applicable
- Selection is only considered valid if it's non-collapsed and contains non-whitespace text
- Error handling is included to gracefully return `false` if selection access fails
- The keyboard shortcut logic now returns early for copy/cut operations when text is selected, allowing the native browser behavior to take precedence

https://claude.ai/code/session_01Lgrf5rav2QgHEpnpyF87qV