### PR TITLE
Refactor update UI logic to clarify shell vs source updates

### DIFF
--- a/protovibe-project-manager/src/components/VersionInfoMenu.jsx
+++ b/protovibe-project-manager/src/components/VersionInfoMenu.jsx
@@ -34,7 +34,7 @@ export default function VersionInfoMenu({ onUpdateClick }) {
     ;(async () => {
       const data = await check()
       if (cancelled || !data) return
-      if (data.manager?.outdated || data.template?.outdated) {
+      if (sourceUpdateOffered(data)) {
         setOpen(true)
       }
     })()
@@ -61,10 +61,12 @@ export default function VersionInfoMenu({ onUpdateClick }) {
     })
   }
 
-  // Only the source (manager/template) drives the download button — the shell
-  // installs its own updates through electron-updater.
   const sourceOutdated = info && (info.manager?.outdated || info.template?.outdated)
   const shellOutdated = info?.shell?.outdated
+  // The in-app download is offered only when nothing else will bring the new
+  // source along; see sourceUpdateOffered. Under a shell that's about to update
+  // itself the button stays neutral and the popover just reports the versions.
+  const offerUpdate = sourceUpdateOffered(info)
   const anyOutdated = sourceOutdated || shellOutdated
   // Distinct reasons, deduped: the manager and template share one source error.
   const failures = info
@@ -77,15 +79,15 @@ export default function VersionInfoMenu({ onUpdateClick }) {
       <button
         onClick={handleToggle}
         className={`relative flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
-          anyOutdated
+          offerUpdate
             ? 'bg-primary text-foreground-on-primary hover:bg-primary-hover'
             : 'bg-background-secondary text-foreground-default hover:bg-background-tertiary'
         }`}
       >
-        {anyOutdated ? <Download size={14} /> : null}
-        {anyOutdated ? 'Update available' : 'Version info'}
+        {offerUpdate ? <Download size={14} /> : null}
+        {offerUpdate ? 'Update available' : 'Version info'}
         <ChevronDown size={12} className={`transition-transform ${open ? 'rotate-180' : ''}`} />
-        {anyOutdated && (
+        {offerUpdate && (
           <span className="absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full bg-foreground-destructive border-2 border-background-elevated" />
         )}
       </button>
@@ -120,7 +122,7 @@ export default function VersionInfoMenu({ onUpdateClick }) {
 
               <div className="h-px bg-border-default" />
 
-              {sourceOutdated && (
+              {offerUpdate && (
                 <div className="flex flex-col gap-2">
                   <p className="text-xs text-foreground-secondary">
                     Each of your projects picks up the new Protovibe editor the next time you run it.
@@ -140,7 +142,8 @@ export default function VersionInfoMenu({ onUpdateClick }) {
               {shellOutdated && (
                 <p className="text-xs text-foreground-secondary">
                   Protovibe {info.shell.latest} is available. The app downloads it on its
-                  own and will ask you to restart when it's ready to install.
+                  own and will ask you to restart when it's ready to install
+                  {sourceOutdated ? ', bringing the new project manager and template with it' : ''}.
                 </p>
               )}
 
@@ -173,6 +176,20 @@ export default function VersionInfoMenu({ onUpdateClick }) {
       )}
     </div>
   )
+}
+
+// Whether the popover should push the in-app "Download new version" flow.
+// Under the Electron shell, electron-updater ships the manager and template
+// inside the next shell release, so a pending shell update already covers any
+// newer source. The in-app download is only needed when nothing else will
+// deliver it: outside the shell, or when the shell itself is current but the
+// manager/template were released on their own without a shell bump.
+function sourceUpdateOffered(info) {
+  if (!info) return false
+  const sourceOutdated = !!(info.manager?.outdated || info.template?.outdated)
+  if (!sourceOutdated) return false
+  if (!info.shell) return true
+  return !info.shell.outdated
 }
 
 function RetryButton({ onClick }) {


### PR DESCRIPTION
## Summary
Extracted the logic for determining when to offer the in-app source update into a dedicated `sourceUpdateOffered()` function, and updated the UI to use this function consistently. This clarifies the distinction between shell updates (handled by electron-updater) and source updates (manager/template), improving code maintainability and fixing the update button behavior.

## Key Changes
- **Extracted `sourceUpdateOffered()` function**: Encapsulates the logic for determining when the in-app download should be offered. The function returns `true` only when a source update is available AND either there's no shell or the shell is current (since a pending shell update will already deliver the new source).
- **Updated button state logic**: Changed the button's visual state (color, icon, text, badge) to use `offerUpdate` instead of `anyOutdated`, ensuring the download button only appears when the in-app flow is actually needed.
- **Fixed popover content visibility**: Changed the download section to show only when `offerUpdate` is true, not just when `sourceOutdated` is true.
- **Improved shell update messaging**: Enhanced the shell update notification to clarify that a pending shell update will also bring the new project manager and template when both are outdated.
- **Added documentation**: Included a detailed comment explaining the update strategy and when each update mechanism applies.

## Implementation Details
The `sourceUpdateOffered()` function implements the following logic:
- Returns `false` if no info is available
- Returns `false` if the source (manager/template) is not outdated
- Returns `true` if there's no shell (standalone mode)
- Returns `true` only if the shell exists but is not outdated (meaning a shell update won't deliver the new source)

This ensures the in-app download is only offered when it's actually needed, avoiding redundant update paths.

https://claude.ai/code/session_01AKKEVEfT68F1oBvMwnMexQ