### PR TITLE
Clear shell text selection when clicking on the canvas

### DIFF
--- a/protovibe-project-template/plugins/protovibe/src/ui/context/ProtovibeContext.tsx
+++ b/protovibe-project-template/plugins/protovibe/src/ui/context/ProtovibeContext.tsx
@@ -232,9 +232,15 @@ export const ProtovibeProvider: React.FC<{ children: React.ReactNode }> = ({ chi
 
   // When the user clicks inside any iframe, dispatch a synthetic mousedown on the
   // shell document so all click-outside handlers (dropdowns, menus, etc.) close automatically.
+  // Also clear any text selection in the shell: the canvas bridge calls
+  // preventDefault on pointerdown, so the iframe never takes focus and the
+  // browser does not collapse the shell's selection on its own. Without this,
+  // text highlighted in the shell (e.g. a comment) would keep hijacking
+  // Cmd+C / Cmd+X after the user clicked a block on the canvas.
   useEffect(() => {
     const handleMessage = (e: MessageEvent) => {
       if (e.data?.type === 'PV_IFRAME_POINTER_DOWN') {
+        try { window.getSelection()?.removeAllRanges(); } catch {}
         document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
       }
     };


### PR DESCRIPTION
Follow-up to #32.

The canvas bridge calls `preventDefault` on pointerdown, so the iframe never takes focus and the shell's text selection survives a canvas click. That selection then kept Cmd+C / Cmd+X in text-copy mode even after the user had selected a block, requiring an extra click on empty shell space.

This clears the shell selection in the existing `PV_IFRAME_POINTER_DOWN` handler in `ProtovibeContext.tsx`, so block copy works immediately after clicking a block. Selecting text after a block is focused still copies the text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lgrf5rav2QgHEpnpyF87qV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lgrf5rav2QgHEpnpyF87qV)_