### PR TITLE
electron: restart the recursive delete on ENOTEMPTY during update

### DIFF
--- a/electron/src/refresh-workspace.js
+++ b/electron/src/refresh-workspace.js
@@ -2,12 +2,32 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 // Big trees (node_modules is ~100k files) intermittently fail to delete on
-// macOS with ENOTEMPTY/EBUSY as the filesystem catches up; Node retries those
-// exact errors when asked to. Every recursive delete in the shell goes
-// through here.
-const RM_OPTS = { recursive: true, force: true, maxRetries: 5, retryDelay: 200 };
-function rmTree(p) {
-  fs.rmSync(p, RM_OPTS);
+// macOS with ENOTEMPTY/EBUSY as the filesystem catches up. Node's own
+// maxRetries only re-issues the final rmdir() of a directory — it never
+// re-walks the children — so when a child is still lingering (or Finder /
+// Spotlight dropped a .DS_Store back in) every one of those retries fails
+// the same way and the update dies with "ENOTEMPTY: rmdir '.../plugins'".
+// The outer loop here restarts the whole recursive delete, which re-scans
+// and removes whatever is left, with backoff between attempts (~6s total).
+// Every recursive delete in the shell goes through here.
+const RM_OPTS = { recursive: true, force: true, maxRetries: 3, retryDelay: 100 };
+const RM_RETRY_CODES = new Set(['ENOTEMPTY', 'EBUSY', 'EPERM', 'EMFILE', 'ENFILE']);
+const RM_ATTEMPTS = 7;
+const RM_BASE_DELAY_MS = 100;
+
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function rmTree(p, { attempt = (target) => fs.rmSync(target, RM_OPTS), sleep = sleepSync } = {}) {
+  for (let i = 1; ; i++) {
+    try {
+      return attempt(p);
+    } catch (err) {
+      if (i >= RM_ATTEMPTS || !RM_RETRY_CODES.has(err.code)) throw err;
+      sleep(RM_BASE_DELAY_MS * 2 ** (i - 1));
+    }
+  }
 }
 
 // Where a workspace's node_modules is parked while its sources are replaced.

--- a/electron/test/refresh-workspace.test.cjs
+++ b/electron/test/refresh-workspace.test.cjs
@@ -79,3 +79,53 @@ test('node_modules is put back even when the copy fails', (t) => {
   assert.ok(fs.existsSync(path.join(wsDir, 'node_modules', 'left-pad', 'index.js')));
   assert.ok(!fs.existsSync(stashPath(root, WS)));
 });
+
+// Node's rmSync retries only the final rmdir(); a child that is still there
+// (or reappeared) makes every retry fail the same way. rmTree must restart
+// the whole recursive delete until it goes through.
+test('rmTree restarts the recursive delete on ENOTEMPTY', (t) => {
+  const { tmp, wsDir } = setup();
+  t.after(() => fs.rmSync(tmp, { recursive: true, force: true }));
+  const { rmTree } = require('../src/refresh-workspace');
+  const delays = [];
+  let calls = 0;
+  const attempt = (target) => {
+    calls++;
+    if (calls <= 2) {
+      const err = new Error(`ENOTEMPTY: directory not empty, rmdir '${target}'`);
+      err.code = 'ENOTEMPTY';
+      throw err;
+    }
+    fs.rmSync(target, { recursive: true, force: true });
+  };
+  rmTree(wsDir, { attempt, sleep: (ms) => delays.push(ms) });
+  assert.equal(calls, 3);
+  assert.deepEqual(delays, [100, 200], 'backs off between attempts');
+  assert.ok(!fs.existsSync(wsDir));
+});
+
+test('rmTree gives up on errors that will not go away', () => {
+  const { rmTree } = require('../src/refresh-workspace');
+  let calls = 0;
+  const attempt = () => {
+    calls++;
+    const err = new Error('EACCES');
+    err.code = 'EACCES';
+    throw err;
+  };
+  assert.throws(() => rmTree('/nope', { attempt, sleep: () => {} }), { code: 'EACCES' });
+  assert.equal(calls, 1);
+});
+
+test('rmTree rethrows after the retry budget is spent', () => {
+  const { rmTree } = require('../src/refresh-workspace');
+  const delays = [];
+  const attempt = () => {
+    const err = new Error('ENOTEMPTY');
+    err.code = 'ENOTEMPTY';
+    throw err;
+  };
+  assert.throws(() => rmTree('/nope', { attempt, sleep: (ms) => delays.push(ms) }), { code: 'ENOTEMPTY' });
+  assert.equal(delays.length, 6);
+  assert.equal(delays.reduce((a, b) => a + b, 0), 6300);
+});


### PR DESCRIPTION
## Problem

While the shell auto-updates, the template refresh intermittently fails with:

```
ENOTEMPTY: directory not empty, rmdir '.../protovibe-project-template/plugins'
```

Hitting Retry then works. The refresh wipes the whole workspace tree via `rmTree`, which relied on Node's built-in `rmSync` `maxRetries`. That retry only re-issues the final `rmdir()` of a directory and never re-walks its children, so when something under `plugins/` was still lingering (or macOS dropped a `.DS_Store` back in) every retry failed identically.

## Fix

`rmTree` in `electron/src/refresh-workspace.js` now wraps `rmSync` in its own loop that restarts the entire recursive delete on `ENOTEMPTY`/`EBUSY`/`EPERM` with exponential backoff (100ms doubling, 7 attempts, ~6s budget). Restarting re-scans and removes whatever is left. Non-retryable errors still throw immediately. Every recursive delete in the shell already goes through `rmTree`, so the staged-update `.old` swap gets the same protection.

## Tests

Three new tests in `electron/test/refresh-workspace.test.cjs`: restart on ENOTEMPTY with the expected backoff schedule, immediate throw on non-retryable errors, and rethrow once the budget is spent. All 15 electron unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6RFZLFZKKU1oazma9HGLN

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6RFZLFZKKU1oazma9HGLN)_